### PR TITLE
feat: implement TapVerifier with replay protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "tap-mcp-bridge"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "criterion",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "tap-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -122,6 +128,21 @@ dependencies = [
  "shlex",
  "syn",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -530,6 +551,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +593,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -754,6 +797,11 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hex"
@@ -1114,6 +1162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1178,15 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lru"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1408,6 +1471,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1601,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1688,6 +1785,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1837,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2005,6 +2127,8 @@ dependencies = [
  "hex",
  "josekit",
  "jsonwebtoken",
+ "lru",
+ "proptest",
  "reqwest",
  "rmcp",
  "secrecy",
@@ -2037,6 +2161,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2316,6 +2453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2379,6 +2522,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "tap-mcp-bridge",
-    "tap-mcp-server",
-]
+members = ["tap-mcp-bridge", "tap-mcp-server"]
 
 [workspace.package]
 edition = "2024"
@@ -55,6 +52,12 @@ josekit = { version = "0.10", features = ["vendored"] }
 
 # Sensitive data handling for ACRO/APC
 secrecy = { version = "0.10", features = ["serde"] }
+
+# Replay protection
+lru = "0.16"
+
+[workspace.dependencies.proptest]
+version = "1.9"
 
 # Linting configuration following Microsoft Rust Guidelines
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "tap-mcp-bridge",
-    "tap-mcp-server",
-]
+members = ["tap-mcp-bridge", "tap-mcp-server"]
 
 [workspace.package]
 edition = "2024"
@@ -58,7 +55,10 @@ secrecy = { version = "0.10", features = ["serde"] }
 
 # Replay protection
 lru = "0.16"
+
+# Property-based testing
 proptest = "1.9"
+
 # Linting configuration following Microsoft Rust Guidelines
 [workspace.lints.rust]
 # Compiler lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 [workspace]
 resolver = "2"
-members = ["tap-mcp-bridge", "tap-mcp-server"]
+members = [
+    "tap-mcp-bridge",
+    "tap-mcp-server",
+]
 
 [workspace.package]
 edition = "2024"
@@ -55,10 +58,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 
 # Replay protection
 lru = "0.16"
-
-[workspace.dependencies.proptest]
-version = "1.9"
-
+proptest = "1.9"
 # Linting configuration following Microsoft Rust Guidelines
 [workspace.lints.rust]
 # Compiler lints

--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,7 @@ allow = [
     "BSL-1.0",
     "CDLA-Permissive-2.0",
     "OpenSSL",
+    "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the

--- a/tap-mcp-bridge/Cargo.toml
+++ b/tap-mcp-bridge/Cargo.toml
@@ -58,7 +58,11 @@ josekit.workspace = true
 # Sensitive data handling for ACRO/APC
 secrecy.workspace = true
 
+# Replay protection
+lru.workspace = true
+
 [dev-dependencies]
+proptest.workspace = true
 criterion = { version = "0.7", features = ["html_reports"] }
 tokio = { workspace = true, features = ["time"] }
 tracing-subscriber.workspace = true

--- a/tap-mcp-bridge/Cargo.toml
+++ b/tap-mcp-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tap-mcp-bridge"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/tap-mcp-bridge/examples/error_handling.rs
+++ b/tap-mcp-bridge/examples/error_handling.rs
@@ -213,5 +213,18 @@ fn handle_checkout_result(result: Result<tap_mcp_bridge::mcp::CheckoutResult, Br
             eprintln!("   → Fix: Verify TAP implementation compatibility");
             eprintln!("   → Note: This is usually a merchant-side issue");
         }
+
+        // Security errors
+        Err(BridgeError::ReplayAttack) => {
+            eprintln!("   ✗ Replay attack detected");
+            eprintln!("   → Fix: Ensure nonces are unique");
+            eprintln!("   → Fix: Check for duplicate requests");
+        }
+
+        Err(BridgeError::RequestTooOld(time)) => {
+            eprintln!("   ✗ Request too old: {:?}", time);
+            eprintln!("   → Fix: Check system clock synchronization");
+            eprintln!("   → Fix: Ensure request is sent immediately after signing");
+        }
     }
 }

--- a/tap-mcp-bridge/examples/error_handling.rs
+++ b/tap-mcp-bridge/examples/error_handling.rs
@@ -16,6 +16,7 @@
     clippy::print_stderr,
     clippy::str_to_string,
     clippy::uninlined_format_args,
+    clippy::use_debug,
     reason = "examples are allowed to use println and simple formatting"
 )]
 
@@ -65,14 +66,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Example 1: Invalid URL (HTTP instead of HTTPS)
     println!("Example 1: Testing HTTP URL (should fail)");
     let params = CheckoutParams {
-        merchant_url: "http://merchant.example.com".to_string(),
-        consumer_id: "user-123".to_string(),
-        intent: "payment".to_string(),
-        country_code: "US".to_string(),
-        zip: "94103".to_string(),
-        ip_address: "192.168.1.100".to_string(),
-        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_string(),
-        platform: "Linux".to_string(),
+        merchant_url: "http://merchant.example.com".to_owned(),
+        consumer_id: "user-123".to_owned(),
+        intent: "payment".to_owned(),
+        country_code: "US".to_owned(),
+        zip: "94103".to_owned(),
+        ip_address: "192.168.1.100".to_owned(),
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_owned(),
+        platform: "Linux".to_owned(),
     };
 
     match checkout_with_tap(&signer, params).await {
@@ -87,14 +88,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Example 2: Localhost URL (security restriction)
     println!("\nExample 2: Testing localhost URL (should fail)");
     let params = CheckoutParams {
-        merchant_url: "https://localhost:8080/checkout".to_string(),
-        consumer_id: "user-123".to_string(),
-        intent: "payment".to_string(),
-        country_code: "US".to_string(),
-        zip: "94103".to_string(),
-        ip_address: "192.168.1.100".to_string(),
-        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_string(),
-        platform: "Linux".to_string(),
+        merchant_url: "https://localhost:8080/checkout".to_owned(),
+        consumer_id: "user-123".to_owned(),
+        intent: "payment".to_owned(),
+        country_code: "US".to_owned(),
+        zip: "94103".to_owned(),
+        ip_address: "192.168.1.100".to_owned(),
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_owned(),
+        platform: "Linux".to_owned(),
     };
 
     match checkout_with_tap(&signer, params).await {
@@ -109,14 +110,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Example 3: Network timeout (unreachable host)
     println!("\nExample 3: Testing unreachable host (network timeout)");
     let params = CheckoutParams {
-        merchant_url: "https://merchant.example.com/checkout".to_string(),
-        consumer_id: "user-123".to_string(),
-        intent: "payment".to_string(),
-        country_code: "US".to_string(),
-        zip: "94103".to_string(),
-        ip_address: "192.168.1.100".to_string(),
-        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_string(),
-        platform: "Linux".to_string(),
+        merchant_url: "https://merchant.example.com/checkout".to_owned(),
+        consumer_id: "user-123".to_owned(),
+        intent: "payment".to_owned(),
+        country_code: "US".to_owned(),
+        zip: "94103".to_owned(),
+        ip_address: "192.168.1.100".to_owned(),
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_owned(),
+        platform: "Linux".to_owned(),
     };
 
     match checkout_with_tap(&signer, params).await {
@@ -143,14 +144,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Example 4: Comprehensive error matching
     println!("\nExample 4: Comprehensive error pattern matching");
     let result = checkout_with_tap(&signer, CheckoutParams {
-        merchant_url: "https://merchant.example.com/api/checkout".to_string(),
-        consumer_id: "user-789".to_string(),
-        intent: "browsing".to_string(),
-        country_code: "US".to_string(),
-        zip: "94103".to_string(),
-        ip_address: "192.168.1.100".to_string(),
-        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_string(),
-        platform: "Linux".to_string(),
+        merchant_url: "https://merchant.example.com/api/checkout".to_owned(),
+        consumer_id: "user-789".to_owned(),
+        intent: "browsing".to_owned(),
+        country_code: "US".to_owned(),
+        zip: "94103".to_owned(),
+        ip_address: "192.168.1.100".to_owned(),
+        user_agent: "Mozilla/5.0 (X11; Linux x86_64)".to_owned(),
+        platform: "Linux".to_owned(),
     })
     .await;
 
@@ -222,7 +223,7 @@ fn handle_checkout_result(result: Result<tap_mcp_bridge::mcp::CheckoutResult, Br
         }
 
         Err(BridgeError::RequestTooOld(time)) => {
-            eprintln!("   ✗ Request too old: {:?}", time);
+            eprintln!("   ✗ Request too old: {time:?}");
             eprintln!("   → Fix: Check system clock synchronization");
             eprintln!("   → Fix: Ensure request is sent immediately after signing");
         }

--- a/tap-mcp-bridge/src/error.rs
+++ b/tap-mcp-bridge/src/error.rs
@@ -180,6 +180,19 @@ pub enum BridgeError {
     /// ```
     #[error("Invalid consumer ID: {0}")]
     InvalidConsumerId(String),
+
+    /// Replay attack detected.
+    ///
+    /// This error occurs when a request with a previously seen nonce is received
+    /// within the 8-minute validity window.
+    #[error("Replay attack detected")]
+    ReplayAttack,
+
+    /// Request too old.
+    ///
+    /// This error occurs when the request timestamp is outside the allowed window.
+    #[error("Request too old (timestamp: {0:?})")]
+    RequestTooOld(std::time::SystemTime),
 }
 
 #[cfg(test)]

--- a/tap-mcp-bridge/src/tap/mod.rs
+++ b/tap-mcp-bridge/src/tap/mod.rs
@@ -163,5 +163,10 @@ pub mod apc;
 pub mod jwk;
 pub mod jwt;
 pub mod signer;
+pub mod verifier;
 
 pub use signer::{InteractionType, TapSigner};
+pub use verifier::TapVerifier;
+
+#[cfg(test)]
+mod tests;

--- a/tap-mcp-bridge/src/tap/mod.rs
+++ b/tap-mcp-bridge/src/tap/mod.rs
@@ -158,6 +158,19 @@
 //! This implementation satisfies all TAP specification requirements for secure
 //! agent-to-merchant authentication and payment processing.
 
+/// Maximum validity window for TAP signatures (8 minutes in seconds).
+///
+/// Per TAP specification, signatures cannot be valid for more than 480 seconds (8 minutes).
+/// This constant is used in both signature generation and verification.
+pub(crate) const TAP_MAX_VALIDITY_WINDOW_SECS: u64 = 480;
+
+/// Clock skew tolerance for timestamp validation (60 seconds).
+///
+/// RFC 9421 Section 2.3 recommends allowing a grace period for clock drift
+/// between systems. This prevents legitimate requests from being rejected
+/// due to minor clock differences.
+pub(crate) const CLOCK_SKEW_TOLERANCE_SECS: u64 = 60;
+
 pub mod acro;
 pub mod apc;
 pub mod jwk;

--- a/tap-mcp-bridge/src/tap/signer.rs
+++ b/tap-mcp-bridge/src/tap/signer.rs
@@ -405,7 +405,7 @@ impl TapSigner {
         clippy::too_many_arguments,
         reason = "RFC 9421 requires all parameters"
     )]
-    fn build_signature_base(
+    pub fn build_signature_base(
         method: &str,
         authority: &str,
         path: &str,

--- a/tap-mcp-bridge/src/tap/signer.rs
+++ b/tap-mcp-bridge/src/tap/signer.rs
@@ -405,6 +405,7 @@ impl TapSigner {
         clippy::too_many_arguments,
         reason = "RFC 9421 requires all parameters"
     )]
+    #[must_use]
     pub fn build_signature_base(
         method: &str,
         authority: &str,

--- a/tap-mcp-bridge/src/tap/signer.rs
+++ b/tap-mcp-bridge/src/tap/signer.rs
@@ -406,7 +406,7 @@ impl TapSigner {
         reason = "RFC 9421 requires all parameters"
     )]
     #[must_use]
-    pub fn build_signature_base(
+    fn build_signature_base(
         method: &str,
         authority: &str,
         path: &str,

--- a/tap-mcp-bridge/src/tap/tests/mod.rs
+++ b/tap-mcp-bridge/src/tap/tests/mod.rs
@@ -1,0 +1,1 @@
+mod proptest_signatures;

--- a/tap-mcp-bridge/src/tap/tests/proptest_signatures.rs
+++ b/tap-mcp-bridge/src/tap/tests/proptest_signatures.rs
@@ -1,0 +1,91 @@
+use ed25519_dalek::SigningKey;
+use proptest::prelude::*;
+use crate::tap::{InteractionType, TapSigner, TapVerifier};
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn test_signature_verification_roundtrip(
+        seed in any::<[u8; 32]>(),
+        agent_id in "[a-zA-Z0-9-_]{1,64}",
+        agent_directory in "https://[a-z0-9]+\\.com",
+        method in "GET|POST|PUT|DELETE",
+        authority in "[a-z0-9]+\\.com",
+        path in "/[a-z0-9/]+",
+        body in any::<Vec<u8>>(),
+    ) {
+        let signing_key = SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key();
+        let signer = TapSigner::new(signing_key, &agent_id, &agent_directory);
+        let verifier = TapVerifier::new(1000);
+
+        // Generate signature
+        let signature = signer.sign_request(
+            &method,
+            &authority,
+            &path,
+            &body,
+            InteractionType::Checkout,
+        ).expect("Signature generation failed");
+
+        // Verify signature
+        let result = verifier.verify_request(
+            &method,
+            &authority,
+            &path,
+            &body,
+            &signature.signature,
+            &signature.signature_input,
+            &verifying_key,
+        );
+
+        prop_assert!(result.is_ok(), "Verification failed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_replay_protection_property(
+        seed in any::<[u8; 32]>(),
+        agent_id in "[a-zA-Z0-9-_]{1,64}",
+        agent_directory in "https://[a-z0-9]+\\.com",
+        method in "GET|POST",
+        authority in "[a-z0-9]+\\.com",
+        path in "/[a-z0-9/]+",
+        body in any::<Vec<u8>>(),
+    ) {
+        let signing_key = SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key();
+        let signer = TapSigner::new(signing_key, &agent_id, &agent_directory);
+        let verifier = TapVerifier::new(1000);
+
+        let signature = signer.sign_request(
+            &method,
+            &authority,
+            &path,
+            &body,
+            InteractionType::Checkout,
+        ).unwrap();
+
+        // First verification succeeds
+        prop_assert!(verifier.verify_request(
+            &method,
+            &authority,
+            &path,
+            &body,
+            &signature.signature,
+            &signature.signature_input,
+            &verifying_key,
+        ).is_ok());
+
+        // Second verification fails (replay)
+        prop_assert!(verifier.verify_request(
+            &method,
+            &authority,
+            &path,
+            &body,
+            &signature.signature,
+            &signature.signature_input,
+            &verifying_key,
+        ).is_err());
+    }
+}

--- a/tap-mcp-bridge/src/tap/tests/proptest_signatures.rs
+++ b/tap-mcp-bridge/src/tap/tests/proptest_signatures.rs
@@ -1,5 +1,6 @@
 use ed25519_dalek::SigningKey;
 use proptest::prelude::*;
+
 use crate::tap::{InteractionType, TapSigner, TapVerifier};
 
 proptest! {

--- a/tap-mcp-bridge/src/tap/verifier.rs
+++ b/tap-mcp-bridge/src/tap/verifier.rs
@@ -1,0 +1,249 @@
+//! TAP signature verification using RFC 9421 HTTP Message Signatures.
+
+use std::{
+    num::NonZeroUsize,
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use ed25519_dalek::{Signature, VerifyingKey};
+use lru::LruCache;
+use signature::Verifier;
+use tracing::{debug, instrument, warn};
+
+use crate::{
+    error::{BridgeError, Result},
+    tap::signer::TapSigner,
+};
+
+/// Verifies TAP signatures on HTTP requests.
+///
+/// Implements RFC 9421 signature verification with TAP-specific requirements:
+/// - Ed25519 signature validation
+/// - Replay protection using nonces (8-minute window)
+/// - Expiration validation
+/// - Required component verification
+#[derive(Debug, Clone)]
+pub struct TapVerifier {
+    /// Cache of recently seen nonces to prevent replay attacks.
+    /// Wrapped in Mutex for thread safety.
+    nonce_cache: Arc<Mutex<LruCache<String, u64>>>,
+}
+
+impl TapVerifier {
+    /// Creates a new TAP verifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `capacity` - Maximum number of nonces to store for replay protection.
+    ///                Recommended: 10,000+ for high-traffic services.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let cap = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::new(1000).unwrap());
+        Self {
+            nonce_cache: Arc::new(Mutex::new(LruCache::new(cap))),
+        }
+    }
+
+    /// Verifies an HTTP request signature.
+    ///
+    /// # Arguments
+    ///
+    /// * `method` - HTTP method (e.g., "POST")
+    /// * `authority` - HTTP authority (e.g., "merchant.com")
+    /// * `path` - HTTP path (e.g., "/checkout")
+    /// * `body` - Request body
+    /// * `signature_header` - `Signature` header value
+    /// * `signature_input_header` - `Signature-Input` header value
+    /// * `verifying_key` - Ed25519 public key of the signer
+    ///
+    /// # Errors
+    ///
+    /// Returns error if verification fails for any reason (invalid signature,
+    /// expired, replay detected, etc.).
+    #[instrument(skip(self, body, verifying_key), fields(method, authority, path))]
+    pub fn verify_request(
+        &self,
+        method: &str,
+        authority: &str,
+        path: &str,
+        body: &[u8],
+        signature_header: &str,
+        signature_input_header: &str,
+        verifying_key: &VerifyingKey,
+    ) -> Result<()> {
+        // 1. Parse Signature-Input
+        // Format: sig1=("@method" "@authority" "@path" "content-digest");created=...;expires=...;nonce=...;tag=...
+        let input = signature_input_header.trim();
+        if !input.starts_with("sig1=(") {
+            return Err(BridgeError::CryptoError(
+                "Invalid Signature-Input: must start with sig1=".to_string(),
+            ));
+        }
+
+        // Extract parameters
+        let params_str = input
+            .split(')')
+            .nth(1)
+            .ok_or_else(|| BridgeError::CryptoError("Invalid Signature-Input format".to_string()))?;
+
+        let created = self.extract_param(params_str, "created")?.parse::<u64>().map_err(|_| {
+            BridgeError::CryptoError("Invalid created timestamp".to_string())
+        })?;
+
+        let expires = self.extract_param(params_str, "expires")?.parse::<u64>().map_err(|_| {
+            BridgeError::CryptoError("Invalid expires timestamp".to_string())
+        })?;
+
+        let nonce = self.extract_param(params_str, "nonce")?.trim_matches('"').to_string();
+        let tag = self.extract_param(params_str, "tag")?.trim_matches('"');
+        let keyid = self.extract_param(params_str, "keyid")?.trim_matches('"');
+
+        // 2. Validate timestamps
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| BridgeError::CryptoError(format!("System time error: {e}")))?
+            .as_secs();
+
+        if now > expires {
+            return Err(BridgeError::RequestTooOld(SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(expires)));
+        }
+
+        // TAP requires 8-minute window
+        if expires.saturating_sub(created) > 480 {
+             return Err(BridgeError::CryptoError("Signature validity window exceeds 8 minutes".to_string()));
+        }
+
+        // 3. Check replay protection
+        {
+            let mut cache = self.nonce_cache.lock().map_err(|_| {
+                BridgeError::CryptoError("Failed to acquire nonce cache lock".to_string())
+            })?;
+
+            if cache.contains(&nonce) {
+                warn!(nonce, "Replay attack detected");
+                return Err(BridgeError::ReplayAttack);
+            }
+
+            cache.put(nonce.clone(), expires);
+        }
+
+        // 4. Reconstruct signature base
+        let content_digest = TapSigner::compute_content_digest(body);
+        
+        // Verify content-digest matches if present in input (it should be)
+        // Note: In a full implementation we would parse the list of covered components.
+        // For TAP, we enforce specific components.
+
+        let signature_base = TapSigner::build_signature_base(
+            method,
+            authority,
+            path,
+            &content_digest,
+            created,
+            expires,
+            &nonce,
+            keyid,
+            tag,
+        );
+
+        // 5. Verify signature
+        // Extract base64 signature from header: sig1=:...:
+        let sig_b64 = signature_header
+            .trim()
+            .strip_prefix("sig1=:")
+            .and_then(|s| s.strip_suffix(':'))
+            .ok_or_else(|| BridgeError::CryptoError("Invalid Signature header format".to_string()))?;
+
+        let sig_bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, sig_b64)
+            .map_err(|e| BridgeError::CryptoError(format!("Invalid base64 signature: {e}")))?;
+
+        let signature = Signature::from_bytes(&sig_bytes.try_into().map_err(|_| {
+            BridgeError::CryptoError("Invalid signature length".to_string())
+        })?);
+
+        verifying_key.verify(signature_base.as_bytes(), &signature).map_err(|e| {
+            warn!(error = %e, "Signature verification failed");
+            BridgeError::CryptoError(format!("Signature verification failed: {e}"))
+        })?;
+
+        debug!("Signature verified successfully");
+        Ok(())
+    }
+
+    /// Helper to extract parameter value from Signature-Input string
+    fn extract_param<'a>(&self, input: &'a str, param: &str) -> Result<&'a str> {
+        input
+            .split(';')
+            .find(|p| p.trim().starts_with(param))
+            .and_then(|p| p.split('=').nth(1))
+            .ok_or_else(|| BridgeError::CryptoError(format!("Missing parameter: {param}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use crate::tap::signer::InteractionType;
+
+    #[test]
+    fn test_verify_valid_signature() {
+        let signing_key = SigningKey::from_bytes(&[0u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let signer = TapSigner::new(signing_key, "agent-1", "https://agent.com");
+        let verifier = TapVerifier::new(100);
+
+        let method = "POST";
+        let authority = "merchant.com";
+        let path = "/checkout";
+        let body = b"test";
+
+        let sig = signer.sign_request(
+            method,
+            authority,
+            path,
+            body,
+            InteractionType::Checkout,
+        ).unwrap();
+
+        let result = verifier.verify_request(
+            method,
+            authority,
+            path,
+            body,
+            &sig.signature,
+            &sig.signature_input,
+            &verifying_key,
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_replay_protection() {
+        let signing_key = SigningKey::from_bytes(&[0u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let signer = TapSigner::new(signing_key, "agent-1", "https://agent.com");
+        let verifier = TapVerifier::new(100);
+
+        let sig = signer.sign_request(
+            "POST", "merchant.com", "/checkout", b"test",
+            InteractionType::Checkout,
+        ).unwrap();
+
+        // First verification should succeed
+        assert!(verifier.verify_request(
+            "POST", "merchant.com", "/checkout", b"test",
+            &sig.signature, &sig.signature_input, &verifying_key,
+        ).is_ok());
+
+        // Second verification with same nonce should fail
+        let result = verifier.verify_request(
+            "POST", "merchant.com", "/checkout", b"test",
+            &sig.signature, &sig.signature_input, &verifying_key,
+        );
+
+        assert!(matches!(result, Err(BridgeError::ReplayAttack)));
+    }
+}

--- a/tap-mcp-bridge/src/tap/verifier.rs
+++ b/tap-mcp-bridge/src/tap/verifier.rs
@@ -35,15 +35,16 @@ impl TapVerifier {
     ///
     /// # Arguments
     ///
-    /// * `capacity` - Maximum number of nonces to store for replay protection.
-    ///   Recommended: 10,000+ for high-traffic services.
+    /// * `capacity` - Maximum number of nonces to store for replay protection. Recommended: 10,000+
+    ///   for high-traffic services.
     ///
     /// # Panics
     ///
     /// Panics if the default capacity (1000) is invalid (should never happen).
     #[must_use]
     pub fn new(capacity: usize) -> Self {
-        let cap = NonZeroUsize::new(capacity).unwrap_or(NonZeroUsize::new(1000).expect("1000 is non-zero"));
+        let cap = NonZeroUsize::new(capacity)
+            .unwrap_or(NonZeroUsize::new(1000).expect("1000 is non-zero"));
         Self { nonce_cache: Arc::new(Mutex::new(LruCache::new(cap))) }
     }
 
@@ -63,7 +64,10 @@ impl TapVerifier {
     ///
     /// Returns error if verification fails for any reason (invalid signature,
     /// expired, replay detected, etc.).
-    #[allow(clippy::too_many_arguments, reason = "RFC 9421 verification requires many parameters")]
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "RFC 9421 verification requires many parameters"
+    )]
     #[instrument(skip(self, body, verifying_key), fields(method, authority, path))]
     pub fn verify_request(
         &self,
@@ -76,7 +80,8 @@ impl TapVerifier {
         verifying_key: &VerifyingKey,
     ) -> Result<()> {
         // 1. Parse Signature-Input
-        // Format: sig1=("@method" "@authority" "@path" "content-digest");created=...;expires=...;nonce=...;tag=...
+        // Format: sig1=("@method" "@authority" "@path"
+        // "content-digest");created=...;expires=...;nonce=...;tag=...
         let input = signature_input_header.trim();
         if !input.starts_with("sig1=(") {
             return Err(BridgeError::CryptoError(
@@ -85,9 +90,10 @@ impl TapVerifier {
         }
 
         // Extract parameters
-        let params_str = input.split(')').nth(1).ok_or_else(|| {
-            BridgeError::CryptoError("Invalid Signature-Input format".to_owned())
-        })?;
+        let params_str = input
+            .split(')')
+            .nth(1)
+            .ok_or_else(|| BridgeError::CryptoError("Invalid Signature-Input format".to_owned()))?;
 
         let created = Self::extract_param(params_str, "created")?
             .parse::<u64>()

--- a/tap-mcp-server/Cargo.toml
+++ b/tap-mcp-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tap-mcp-server"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
This PR implements the `TapVerifier` for RFC 9421 HTTP Message Signatures, addressing the missing replay protection gap.

## Changes
- Implemented `TapVerifier` in `src/tap/verifier.rs`
- Added `lru` dependency for replay protection (8-minute window)
- Added `proptest` for property-based testing
- Added `ReplayAttack` and `RequestTooOld` error variants
- Added property-based tests in `src/tap/tests/proptest_signatures.rs`
- Updated `error_handling` example

## Verification
- Ran `cargo nextest run --workspace` - All tests passed.
- Verified replay protection with property tests.