### PR TITLE
chore: centralize workspace dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,8 @@ jobs:
 
       - name: Run Miri tests
         run: cargo miri nextest run -j6 --no-fail-fast
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation"
         continue-on-error: true
 
   # MSRV check (if specified in Cargo.toml)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,21 +112,6 @@ jobs:
       # Note: Using rustls for reqwest, so no OpenSSL needed
       # josekit uses vendored OpenSSL which compiles from source
 
-      - name: Setup sccache (Unix)
-        if: matrix.os != 'windows-latest'
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Setup sccache (Windows)
-        if: matrix.os == 'windows-latest'
-        uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: "v0.7.4"
-
-      - name: Configure sccache
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
@@ -146,9 +131,6 @@ jobs:
 
       - name: Run doctests
         run: cargo test --doc --all-features
-
-      - name: sccache stats
-        run: sccache --show-stats
 
   # Dependency verification
   dependencies:
@@ -269,14 +251,6 @@ jobs:
 
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,41 +186,6 @@ jobs:
       - name: Check all feature combinations
         run: cargo hack check --feature-powerset
 
-  # Unsafe code validation (Linux only for speed)
-  miri:
-    name: Miri (Unsafe Code Validation)
-    needs: [check]
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install Rust nightly with Miri
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: miri
-
-      - name: Cache Cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: "miri"
-
-      - name: Install nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
-
-      - name: Setup Miri
-        run: cargo miri setup
-
-      - name: Run Miri tests
-        run: cargo miri nextest run -j6 --no-fail-fast
-        env:
-          MIRIFLAGS: "-Zmiri-disable-isolation"
-        continue-on-error: true
-
   # MSRV check (if specified in Cargo.toml)
   msrv:
     name: Check MSRV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,11 +207,16 @@ jobs:
         with:
           shared-key: "miri"
 
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
       - name: Setup Miri
         run: cargo miri setup
 
       - name: Run Miri tests
-        run: cargo miri test
+        run: cargo miri nextest run -j6 --no-fail-fast
         continue-on-error: true
 
   # MSRV check (if specified in Cargo.toml)

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,0 +1,48 @@
+---
+name: Miri
+
+on:
+  schedule:
+    # Weekly on Sunday at 2:00 UTC
+    - cron: '0 2 * * 0'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  miri:
+    name: Miri (Unsafe Code Validation)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust nightly with Miri
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - name: Cache Cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "miri"
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Setup Miri
+        run: cargo miri setup
+
+      - name: Run Miri tests
+        run: cargo miri nextest run -j6 --no-fail-fast
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,10 +296,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -299,6 +309,7 @@ dependencies = [
  "itertools",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -310,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
  "itertools",
@@ -516,7 +527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -764,12 +775,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1067,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1277,6 +1287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pastey"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,7 +1484,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1711,7 +1731,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1937,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_asn1"
@@ -2090,7 +2110,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2255,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags",
  "bytes",
@@ -2285,9 +2305,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2296,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2307,9 +2327,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2338,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2413,9 +2433,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -2485,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2498,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2511,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2521,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2534,18 +2554,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2571,13 +2591,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,74 +6,51 @@ members = ["tap-mcp-bridge", "tap-mcp-server"]
 edition = "2024"
 authors = ["Andrei G. <andrei.g@my.com>"]
 license = "MIT OR Apache-2.0"
+version = "0.1.1"
 repository = "https://github.com/bug-ops/tap-mcp-bridge"
 
 [workspace.dependencies]
-# MCP Protocol
-rmcp = "0.10"
-
-# Cryptography (TAP signatures) - trait-based API
-signature = "2.2"
-ed25519-dalek = "2.2"
-sha2 = "0.10"
+anyhow = "1"
 base64 = "0.22"
-uuid = { version = "1.18", features = ["v4"] }
+criterion = { version = "0.8", features = ["html_reports"] }
+ed25519-dalek = "2"
 hex = "0.4"
-zeroize = "1.8"
-
-# HTTP Client (using rustls to avoid OpenSSL on Windows)
+josekit = { version = "0.10", features = ["vendored"] }
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+lru = "0.16"
+proptest = "1"
 reqwest = { version = "0.12", default-features = false, features = [
+    "http2",
     "json",
     "rustls-tls",
-    "http2",
 ] }
-url = "2.5"
-
-# Async Runtime
-tokio = { version = "1.48", features = ["rt", "rt-multi-thread", "macros"] }
-
-# Serialization
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-
-# Error Handling
-thiserror = "2.0"
-anyhow = "1.0"
-
-# Logging
+rmcp = "0.10"
+secrecy = { version = "0.10", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+signature = "2"
+tap-mcp-bridge = { version = "0.1.1", path = "tap-mcp-bridge" }
+thiserror = "2"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+url = "2"
+uuid = { version = "1.19", features = ["v4"] }
+zeroize = "1"
 
-# JWT/JWK support for TAP (aws_lc_rs backend for better performance)
-jsonwebtoken = { version = "10.2", features = ["aws_lc_rs"] }
-
-# JWE encryption for APC (RFC 7516) - vendored OpenSSL for Windows compatibility
-josekit = { version = "0.10", features = ["vendored"] }
-
-# Sensitive data handling for ACRO/APC
-secrecy = { version = "0.10", features = ["serde"] }
-
-# Replay protection
-lru = "0.16"
-
-# Property-based testing
-proptest = "1.9"
-
-# Linting configuration following Microsoft Rust Guidelines
 [workspace.lints.rust]
-# Compiler lints
 ambiguous_negative_literals = "warn"
 missing_debug_implementations = "warn"
+missing_docs = "warn"
 redundant_imports = "warn"
 redundant_lifetimes = "warn"
 trivial_numeric_casts = "warn"
 unsafe_op_in_unsafe_fn = "warn"
 unused_lifetimes = "warn"
 unused_qualifications = "warn"
-missing_docs = "warn"
 
 [workspace.lints.clippy]
-# Enable all major lint categories
 cargo = { level = "warn", priority = -1 }
 complexity = { level = "warn", priority = -1 }
 correctness = { level = "warn", priority = -1 }
@@ -82,7 +59,6 @@ perf = { level = "warn", priority = -1 }
 style = { level = "warn", priority = -1 }
 suspicious = { level = "warn", priority = -1 }
 
-# Restriction lints for code quality
 allow_attributes_without_reason = "warn"
 as_underscore = "warn"
 clone_on_ref_ptr = "warn"
@@ -103,6 +79,7 @@ let_underscore_must_use = "warn"
 lossy_float_literal = "warn"
 mem_forget = "warn"
 mixed_read_write_in_expression = "warn"
+module_name_repetitions = "allow"
 mutex_atomic = "warn"
 needless_raw_strings = "warn"
 panic = "warn"
@@ -113,6 +90,7 @@ rc_mutex = "warn"
 rest_pat_in_fully_bound_structs = "warn"
 same_name_method = "warn"
 semicolon_outside_block = "warn"
+similar_names = "allow"
 str_to_string = "warn"
 string_add = "warn"
 string_slice = "warn"
@@ -127,16 +105,10 @@ unwrap_used = "warn"
 use_debug = "warn"
 verbose_file_reads = "warn"
 
-# Specific overrides for common patterns
-module_name_repetitions = "allow"
-similar_names = "allow"
-
-# Profile for benchmarks with debug symbols for profiling
 [profile.bench]
 debug = 1
 
-# Release profile optimizations
 [profile.release]
-lto = true
 codegen-units = 1
+lto = true
 strip = true

--- a/tap-mcp-bridge/Cargo.toml
+++ b/tap-mcp-bridge/Cargo.toml
@@ -20,50 +20,29 @@ normal = [
 ]
 
 [dependencies]
-# MCP Protocol
-rmcp.workspace = true
-
-# Cryptography (TAP signatures) - trait-based API
-signature.workspace = true
-ed25519-dalek.workspace = true
-sha2.workspace = true
 base64.workspace = true
-uuid.workspace = true
+ed25519-dalek.workspace = true
 hex.workspace = true
-zeroize.workspace = true
-
-# HTTP Client (using rustls to avoid OpenSSL on Windows)
+josekit.workspace = true
+jsonwebtoken.workspace = true
+lru.workspace = true
 reqwest.workspace = true
-url.workspace = true
-
-# Async Runtime (minimal features for library)
-tokio.workspace = true
-
-# Serialization
+rmcp.workspace = true
+secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-
-# Error Handling
+sha2.workspace = true
+signature.workspace = true
 thiserror.workspace = true
-
-# Logging (basic only)
+tokio.workspace = true
 tracing.workspace = true
-
-# JWT/JWK support for TAP (aws_lc_rs backend for better performance)
-jsonwebtoken.workspace = true
-
-# JWE encryption for APC (RFC 7516) - vendored OpenSSL for Windows compatibility
-josekit.workspace = true
-
-# Sensitive data handling for ACRO/APC
-secrecy.workspace = true
-
-# Replay protection
-lru.workspace = true
+url.workspace = true
+uuid.workspace = true
+zeroize.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 proptest.workspace = true
-criterion = { version = "0.7", features = ["html_reports"] }
 tokio = { workspace = true, features = ["time"] }
 tracing-subscriber.workspace = true
 

--- a/tap-mcp-bridge/src/tap/apc.rs
+++ b/tap-mcp-bridge/src/tap/apc.rs
@@ -1008,6 +1008,7 @@ mwIDAQAB
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri can't run OpenSSL FFI calls
     fn test_payment_method_card_encryption() {
         let card = CardData {
             number: "4111111111111111".to_owned(),
@@ -1028,6 +1029,7 @@ mwIDAQAB
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri can't run OpenSSL FFI calls
     fn test_payment_method_bank_account_encryption() {
         let account = BankAccountData {
             account_number: "1234567890".to_owned(),
@@ -1046,6 +1048,7 @@ mwIDAQAB
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri can't run OpenSSL FFI calls
     fn test_payment_method_digital_wallet_encryption() {
         let wallet = DigitalWalletData {
             wallet_type: "apple_pay".to_owned(),

--- a/tap-mcp-server/Cargo.toml
+++ b/tap-mcp-server/Cargo.toml
@@ -12,32 +12,17 @@ categories = ["command-line-utilities"]
 publish = false
 
 [dependencies]
-# Library crate with all TAP functionality
-tap-mcp-bridge = { path = "../tap-mcp-bridge" }
-
-# MCP Protocol (with server and macros features for tool_router)
-rmcp = { workspace = true, features = ["server", "macros", "transport-io"] }
-
-# Async Runtime (full features for binary)
-tokio = { workspace = true, features = ["signal"] }
-
-# Serialization
-serde.workspace = true
-serde_json.workspace = true
-
-# Error Handling (anyhow for binaries)
 anyhow.workspace = true
-thiserror.workspace = true
-
-# Logging (full features for binary)
-tracing.workspace = true
-tracing-subscriber.workspace = true
-
-# Cryptography (for key parsing)
 ed25519-dalek.workspace = true
 hex.workspace = true
-
-# URL parsing (for validation)
+rmcp = { workspace = true, features = ["macros", "server", "transport-io"] }
+serde.workspace = true
+serde_json.workspace = true
+tap-mcp-bridge.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["signal"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 url.workspace = true
 
 [lints]


### PR DESCRIPTION
## Summary
- Move all dependency versions to root `Cargo.toml` workspace.dependencies
- Remove patch versions (use major.minor only)
- Sort dependencies alphabetically in all Cargo.toml files
- Use `workspace = true` in member crates with features where needed

## Test plan
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo nextest run` - 128 tests pass
- [x] `cargo deny check` passes