### PR TITLE
feat(merchant): add flexible merchant API abstraction layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,6 +2105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,6 +2314,7 @@ dependencies = [
  "signature",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2489,6 +2499,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,6 +2542,12 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tap-mcp-bridge = { version = "0.2.0", path = "tap-mcp-bridge" }
 tap-mcp-server = { version = "0.2.0", path = "tap-mcp-server" }
 thiserror = "2"
 tokio = "1"
+toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 url = "2"

--- a/tap-mcp-bridge/Cargo.toml
+++ b/tap-mcp-bridge/Cargo.toml
@@ -38,6 +38,7 @@ sha2.workspace = true
 signature.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+toml.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid = { workspace = true, features = ["serde", "v4"] }

--- a/tap-mcp-bridge/examples/error_handling.rs
+++ b/tap-mcp-bridge/examples/error_handling.rs
@@ -245,5 +245,23 @@ fn handle_checkout_result(result: Result<tap_mcp_bridge::mcp::CheckoutResult, Br
             eprintln!("   → Fix: Check input parameter constraints");
             eprintln!("   → Fix: Ensure no null bytes or invalid characters");
         }
+
+        Err(BridgeError::MerchantConfigError(msg)) => {
+            eprintln!("   ✗ Merchant configuration error: {msg}");
+            eprintln!("   → Fix: Check merchant configuration TOML file");
+            eprintln!("   → Fix: Verify all required fields are present");
+        }
+
+        Err(BridgeError::FieldMappingError(msg)) => {
+            eprintln!("   ✗ Field mapping error: {msg}");
+            eprintln!("   → Fix: Check field mapping configuration");
+            eprintln!("   → Fix: Ensure mappings match actual API fields");
+        }
+
+        Err(BridgeError::TransformationError(msg)) => {
+            eprintln!("   ✗ Response transformation error: {msg}");
+            eprintln!("   → Fix: Check merchant response format");
+            eprintln!("   → Fix: Verify custom transformers are correct");
+        }
     }
 }

--- a/tap-mcp-bridge/examples/merchants/acme-store.toml
+++ b/tap-mcp-bridge/examples/merchants/acme-store.toml
@@ -1,0 +1,52 @@
+# ACME Store - Custom Merchant Configuration
+#
+# Example of a merchant with non-standard API conventions.
+# Demonstrates endpoint customization and field mapping.
+
+name = "ACME Store"
+base_url = "https://api.acme-store.com"
+api_prefix = "/api/v2"
+
+[endpoints]
+# Custom catalog endpoints
+products = "/catalog/items"
+product = "/catalog/items/{id}"
+
+# Custom cart/basket endpoints
+cart = "/basket"
+add_to_cart = "/basket/add"
+cart_item = "/basket/line-items/{id}"
+
+# Custom order endpoints
+orders = "/purchases"
+order = "/purchases/{id}"
+checkout = "/purchases/complete"
+
+[field_mappings.request]
+# ACME uses different field names in requests
+consumer_id = "customerId"
+product_id = "sku"
+cart_id = "basketId"
+quantity = "qty"
+variant_id = "variantSku"
+
+[field_mappings.response]
+# Map ACME response fields back to standard TAP names
+customerId = "consumer_id"
+sku = "product_id"
+basketId = "cart_id"
+qty = "quantity"
+variantSku = "variant_id"
+unitPrice = "price"
+lineItems = "items"
+purchaseId = "order_id"
+totalAmount = "total"
+
+# ACME uses offset-based pagination
+pagination = "offset_based"
+
+# ACME requires API key authentication
+[auth]
+type = "api_key"
+header = "X-ACME-API-Key"
+env_var = "ACME_API_KEY"

--- a/tap-mcp-bridge/examples/merchants/shopify-style.toml
+++ b/tap-mcp-bridge/examples/merchants/shopify-style.toml
@@ -1,0 +1,42 @@
+# Shopify-Style Merchant Configuration
+#
+# Example configuration for merchants using Shopify-like API conventions.
+# Uses GraphQL-style naming and cursor-based pagination.
+
+name = "Shopify-Style Store"
+base_url = "https://mystore.myshopify.com"
+api_prefix = "/admin/api/2024-01"
+
+[endpoints]
+products = "/products.json"
+product = "/products/{id}.json"
+cart = "/checkouts"
+add_to_cart = "/checkouts"
+cart_item = "/checkouts/{id}/line_items"
+orders = "/orders.json"
+order = "/orders/{id}.json"
+checkout = "/checkouts/{id}/complete"
+
+[field_mappings.request]
+consumer_id = "customer_id"
+product_id = "variant_id"
+cart_id = "checkout_token"
+quantity = "quantity"
+
+[field_mappings.response]
+customer_id = "consumer_id"
+variant_id = "product_id"
+checkout_token = "cart_id"
+line_items = "items"
+total_price = "total"
+subtotal_price = "subtotal"
+total_tax = "tax"
+created_at = "created_at"
+
+# Shopify uses cursor-based pagination
+pagination = "cursor_based"
+
+# Shopify requires OAuth2 or private app token
+[auth]
+type = "bearer"
+env_var = "SHOPIFY_ACCESS_TOKEN"

--- a/tap-mcp-bridge/examples/merchants/standard-tap.toml
+++ b/tap-mcp-bridge/examples/merchants/standard-tap.toml
@@ -1,0 +1,67 @@
+# Standard TAP Merchant Configuration
+#
+# This is the default configuration for merchants following
+# the standard TAP (Trusted Agent Protocol) API specification.
+#
+# Use this as a template for custom merchant configurations.
+
+name = "Standard TAP Merchant"
+base_url = "https://api.example-merchant.com"
+
+# Optional API prefix (prepended to all endpoints)
+# api_prefix = "/api/v1"
+
+# Endpoint Configuration
+# All endpoints are optional - defaults shown below
+[endpoints]
+products = "/products"
+product = "/products/{id}"
+cart = "/cart"
+add_to_cart = "/cart/add"
+cart_item = "/cart/items/{id}"
+orders = "/orders"
+order = "/orders/{id}"
+checkout = "/checkout"
+
+# Field Mappings
+# Map standard TAP field names to merchant-specific names
+# Leave empty for standard TAP field names
+[field_mappings]
+# Request field mappings (standard -> merchant)
+[field_mappings.request]
+# consumer_id = "consumer_id"
+# product_id = "product_id"
+# cart_id = "cart_id"
+# quantity = "quantity"
+
+# Response field mappings (merchant -> standard)
+[field_mappings.response]
+# id = "id"
+# name = "name"
+# price = "price"
+# items = "items"
+
+# Pagination Style
+# Options: page_based (default), offset_based, cursor_based
+pagination = "page_based"
+
+# Authentication (optional)
+# Supported types: api_key, bearer, oauth2
+
+# Example: API Key authentication
+# [auth]
+# type = "api_key"
+# header = "X-API-Key"
+# env_var = "TAP_MERCHANT_API_KEY"
+
+# Example: Bearer token authentication
+# [auth]
+# type = "bearer"
+# env_var = "TAP_MERCHANT_TOKEN"
+
+# Example: OAuth2 client credentials
+# [auth]
+# type = "oauth2"
+# token_url = "https://auth.example-merchant.com/oauth/token"
+# client_id_env = "TAP_OAUTH_CLIENT_ID"
+# client_secret_env = "TAP_OAUTH_CLIENT_SECRET"

--- a/tap-mcp-bridge/src/error.rs
+++ b/tap-mcp-bridge/src/error.rs
@@ -234,6 +234,24 @@ pub enum BridgeError {
     /// Check the parameter value and ensure it meets the documented requirements.
     #[error("Invalid input: {0}")]
     InvalidInput(String),
+
+    /// Merchant configuration error.
+    ///
+    /// This error occurs when merchant configuration is invalid or cannot be loaded.
+    #[error("Merchant configuration error: {0}")]
+    MerchantConfigError(String),
+
+    /// Field mapping error.
+    ///
+    /// This error occurs when response fields cannot be mapped to standard format.
+    #[error("Field mapping error: {0}")]
+    FieldMappingError(String),
+
+    /// Response transformation error.
+    ///
+    /// This error occurs when a merchant response cannot be transformed to standard format.
+    #[error("Response transformation error: {0}")]
+    TransformationError(String),
 }
 
 #[cfg(test)]

--- a/tap-mcp-bridge/src/lib.rs
+++ b/tap-mcp-bridge/src/lib.rs
@@ -296,11 +296,13 @@
 
 pub mod error;
 pub mod mcp;
+pub mod merchant;
 pub mod reliability;
 pub mod security;
 pub mod tap;
 
 pub use error::{BridgeError, Result};
+pub use merchant::{DefaultMerchant, MerchantApi, MerchantConfig};
 
 #[cfg(test)]
 mod tests {

--- a/tap-mcp-bridge/src/merchant/config.rs
+++ b/tap-mcp-bridge/src/merchant/config.rs
@@ -1,0 +1,1031 @@
+//! Merchant configuration types.
+//!
+//! This module defines TOML-deserializable configuration structures for merchants.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use url::Url;
+
+use crate::error::{BridgeError, Result};
+
+/// Root merchant configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MerchantConfig {
+    /// Merchant display name.
+    pub name: String,
+
+    /// Base URL for the merchant API.
+    pub base_url: String,
+
+    /// API version prefix (e.g., "/api/v1").
+    #[serde(default)]
+    pub api_prefix: String,
+
+    /// Endpoint configuration.
+    #[serde(default)]
+    pub endpoints: EndpointConfig,
+
+    /// Field mapping configuration.
+    #[serde(default)]
+    pub field_mappings: FieldMappingConfig,
+
+    /// Authentication configuration.
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
+
+    /// Pagination style.
+    #[serde(default)]
+    pub pagination: PaginationStyle,
+}
+
+impl Default for MerchantConfig {
+    fn default() -> Self {
+        Self {
+            name: "Default Merchant".to_owned(),
+            base_url: String::new(),
+            api_prefix: String::new(),
+            endpoints: EndpointConfig::default(),
+            field_mappings: FieldMappingConfig::default(),
+            auth: None,
+            pagination: PaginationStyle::default(),
+        }
+    }
+}
+
+impl MerchantConfig {
+    /// Validates the merchant configuration for security issues.
+    ///
+    /// This method checks for:
+    /// - Base URL must be HTTPS (not HTTP)
+    /// - Base URL must not be localhost or loopback addresses
+    /// - Endpoint templates must not contain path traversal sequences
+    /// - Field mapping names must not contain injection patterns
+    /// - Environment variable names in auth config must be alphanumeric
+    /// - `OAuth2` token URLs must be HTTPS
+    ///
+    /// # Errors
+    ///
+    /// Returns `BridgeError::MerchantConfigError` if any validation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tap_mcp_bridge::merchant::MerchantConfig;
+    ///
+    /// let toml = r#"
+    ///     name = "Test"
+    ///     base_url = "https://api.example.com"
+    /// "#;
+    ///
+    /// let config: MerchantConfig = toml::from_str(toml).unwrap();
+    /// assert!(config.validate().is_ok());
+    /// ```
+    pub fn validate(&self) -> Result<()> {
+        // Validate base_url if not empty (empty is allowed for default config)
+        if !self.base_url.is_empty() {
+            self.validate_base_url()?;
+        }
+
+        // Validate endpoint templates
+        self.endpoints.validate()?;
+
+        // Validate field mappings
+        self.field_mappings.validate()?;
+
+        // Validate auth configuration
+        if let Some(ref auth) = self.auth {
+            auth.validate()?;
+        }
+
+        Ok(())
+    }
+
+    /// Validates the base URL.
+    fn validate_base_url(&self) -> Result<()> {
+        let url = Url::parse(&self.base_url).map_err(|e| {
+            BridgeError::MerchantConfigError(format!("invalid base_url '{}': {e}", self.base_url))
+        })?;
+
+        // Must be HTTPS
+        if url.scheme() != "https" {
+            return Err(BridgeError::MerchantConfigError(format!(
+                "base_url must use HTTPS, got: {}",
+                url.scheme()
+            )));
+        }
+
+        // Check for localhost/loopback
+        if let Some(host) = url.host_str() {
+            let host_lower = host.to_lowercase();
+            if host_lower == "localhost"
+                || host_lower == "127.0.0.1"
+                || host_lower == "::1"
+                || host_lower.starts_with("127.")
+                || host_lower == "[::1]"
+            {
+                return Err(BridgeError::MerchantConfigError(format!(
+                    "base_url must not be localhost or loopback: {host}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Endpoint path overrides.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct EndpointConfig {
+    /// Products list endpoint (default: "/products").
+    pub products: Option<String>,
+
+    /// Single product endpoint template (default: "/products/{id}").
+    /// Use `{id}` as placeholder for product ID.
+    pub product: Option<String>,
+
+    /// Cart endpoint (default: "/cart").
+    pub cart: Option<String>,
+
+    /// Add to cart endpoint (default: "/cart/add").
+    pub add_to_cart: Option<String>,
+
+    /// Cart item endpoint template (default: "/cart/items/{id}").
+    pub cart_item: Option<String>,
+
+    /// Orders endpoint (default: "/orders").
+    pub orders: Option<String>,
+
+    /// Single order endpoint template (default: "/orders/{id}").
+    pub order: Option<String>,
+
+    /// Checkout/payment endpoint (default: "/checkout").
+    pub checkout: Option<String>,
+}
+
+impl EndpointConfig {
+    /// Validates endpoint templates for security issues.
+    ///
+    /// Checks that endpoint templates:
+    /// - Do not contain path traversal sequences (`..`, `//`)
+    /// - Do not start with absolute paths on Windows (`C:`, `D:`, etc.)
+    /// - Start with `/` (relative paths only)
+    ///
+    /// # Errors
+    ///
+    /// Returns `BridgeError::MerchantConfigError` if any endpoint is invalid.
+    pub fn validate(&self) -> Result<()> {
+        let endpoints = [
+            ("products", &self.products),
+            ("product", &self.product),
+            ("cart", &self.cart),
+            ("add_to_cart", &self.add_to_cart),
+            ("cart_item", &self.cart_item),
+            ("orders", &self.orders),
+            ("order", &self.order),
+            ("checkout", &self.checkout),
+        ];
+
+        for (name, endpoint) in endpoints {
+            if let Some(path) = endpoint {
+                validate_endpoint_path(name, path)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Validates an endpoint path template for security issues.
+fn validate_endpoint_path(name: &str, path: &str) -> Result<()> {
+    // Check for path traversal
+    if path.contains("..") {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "endpoint '{name}' contains path traversal sequence '..': {path}"
+        )));
+    }
+
+    // Check for double slashes (can be used for path confusion)
+    if path.contains("//") {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "endpoint '{name}' contains double slash '//': {path}"
+        )));
+    }
+
+    // Check for absolute Windows paths
+    if path.len() >= 2 && path.chars().nth(1) == Some(':') {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "endpoint '{name}' appears to be an absolute Windows path: {path}"
+        )));
+    }
+
+    // Must start with /
+    if !path.starts_with('/') {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "endpoint '{name}' must start with '/': {path}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Field name mappings.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct FieldMappingConfig {
+    /// Request field mappings (standard -> merchant).
+    #[serde(default)]
+    pub request: HashMap<String, String>,
+
+    /// Response field mappings (merchant -> standard).
+    #[serde(default)]
+    pub response: HashMap<String, String>,
+}
+
+/// Forbidden field names that could indicate injection attempts.
+const FORBIDDEN_FIELD_NAMES: &[&str] = &[
+    "__proto__",
+    "constructor",
+    "prototype",
+    "__defineGetter__",
+    "__defineSetter__",
+    "__lookupGetter__",
+    "__lookupSetter__",
+];
+
+impl FieldMappingConfig {
+    /// Validates field mapping names for security issues.
+    ///
+    /// Checks that field mapping names:
+    /// - Do not contain JavaScript prototype pollution patterns
+    /// - Do not contain SQL-like injection patterns
+    /// - Do not contain null bytes
+    ///
+    /// # Errors
+    ///
+    /// Returns `BridgeError::MerchantConfigError` if any field name is invalid.
+    pub fn validate(&self) -> Result<()> {
+        for (key, value) in &self.request {
+            validate_field_name("request key", key)?;
+            validate_field_name("request value", value)?;
+        }
+
+        for (key, value) in &self.response {
+            validate_field_name("response key", key)?;
+            validate_field_name("response value", value)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Validates a field name for security issues.
+fn validate_field_name(context: &str, name: &str) -> Result<()> {
+    // Check for forbidden names (prototype pollution)
+    if FORBIDDEN_FIELD_NAMES.contains(&name) {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "{context} contains forbidden name: {name}"
+        )));
+    }
+
+    // Check for null bytes
+    if name.contains('\0') {
+        return Err(BridgeError::MerchantConfigError(format!("{context} contains null byte")));
+    }
+
+    // Check for SQL-like patterns (basic detection)
+    let name_lower = name.to_lowercase();
+    if name_lower.contains("'; drop")
+        || name_lower.contains("-- ")
+        || name_lower.contains("/*")
+        || name_lower.contains("*/")
+    {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "{context} contains suspicious SQL pattern: {name}"
+        )));
+    }
+
+    Ok(())
+}
+
+/// Authentication configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AuthConfig {
+    /// API key authentication.
+    ApiKey {
+        /// Header name for the API key.
+        header: String,
+        /// Environment variable containing the key.
+        env_var: String,
+    },
+    /// Bearer token authentication.
+    Bearer {
+        /// Environment variable containing the token.
+        env_var: String,
+    },
+    /// `OAuth2` client credentials.
+    OAuth2 {
+        /// Token endpoint URL.
+        token_url: String,
+        /// Client ID environment variable.
+        client_id_env: String,
+        /// Client secret environment variable.
+        client_secret_env: String,
+    },
+}
+
+impl AuthConfig {
+    /// Validates authentication configuration for security issues.
+    ///
+    /// Checks that:
+    /// - Environment variable names are alphanumeric with underscores only
+    /// - `OAuth2` token URLs use HTTPS
+    /// - Header names do not contain injection characters
+    ///
+    /// # Errors
+    ///
+    /// Returns `BridgeError::MerchantConfigError` if any value is invalid.
+    pub fn validate(&self) -> Result<()> {
+        match self {
+            Self::ApiKey { header, env_var } => {
+                validate_env_var_name(env_var)?;
+                validate_header_name(header)?;
+            }
+            Self::Bearer { env_var } => {
+                validate_env_var_name(env_var)?;
+            }
+            Self::OAuth2 { token_url, client_id_env, client_secret_env } => {
+                validate_env_var_name(client_id_env)?;
+                validate_env_var_name(client_secret_env)?;
+                validate_oauth_token_url(token_url)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Validates an environment variable name.
+fn validate_env_var_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(BridgeError::MerchantConfigError(
+            "environment variable name cannot be empty".to_owned(),
+        ));
+    }
+
+    // Must be alphanumeric with underscores, starting with letter or underscore
+    // We already checked is_empty, so first char exists
+    let first_char = name.chars().next().expect("name is not empty");
+    if !first_char.is_ascii_alphabetic() && first_char != '_' {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "environment variable name must start with letter or underscore: {name}"
+        )));
+    }
+
+    for ch in name.chars() {
+        if !ch.is_ascii_alphanumeric() && ch != '_' {
+            return Err(BridgeError::MerchantConfigError(format!(
+                "environment variable name contains invalid character '{ch}': {name}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates an HTTP header name.
+fn validate_header_name(name: &str) -> Result<()> {
+    if name.is_empty() {
+        return Err(BridgeError::MerchantConfigError("header name cannot be empty".to_owned()));
+    }
+
+    // HTTP header names: token characters per RFC 7230
+    for ch in name.chars() {
+        if !ch.is_ascii_alphanumeric() && !"-_".contains(ch) {
+            return Err(BridgeError::MerchantConfigError(format!(
+                "header name contains invalid character '{ch}': {name}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validates an `OAuth2` token URL.
+fn validate_oauth_token_url(url: &str) -> Result<()> {
+    let parsed = Url::parse(url).map_err(|e| {
+        BridgeError::MerchantConfigError(format!("invalid OAuth2 token_url '{url}': {e}"))
+    })?;
+
+    // Must be HTTPS
+    if parsed.scheme() != "https" {
+        return Err(BridgeError::MerchantConfigError(format!(
+            "OAuth2 token_url must use HTTPS, got: {}",
+            parsed.scheme()
+        )));
+    }
+
+    // Check for localhost/loopback
+    if let Some(host) = parsed.host_str() {
+        let host_lower = host.to_lowercase();
+        if host_lower == "localhost"
+            || host_lower == "127.0.0.1"
+            || host_lower == "::1"
+            || host_lower.starts_with("127.")
+        {
+            return Err(BridgeError::MerchantConfigError(format!(
+                "OAuth2 token_url must not be localhost or loopback: {host}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Pagination style used by merchant.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaginationStyle {
+    /// Page-based pagination (`page`, `per_page`).
+    #[default]
+    PageBased,
+    /// Offset-based pagination (`offset`, `limit`).
+    OffsetBased,
+    /// Cursor-based pagination (`cursor`, `limit`).
+    CursorBased,
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unreachable,
+    reason = "test code uses unreachable for expected-path assertions"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merchant_config_default() {
+        let config = MerchantConfig::default();
+        assert_eq!(config.name, "Default Merchant");
+        assert!(config.base_url.is_empty());
+    }
+
+    #[test]
+    fn test_merchant_config_from_toml() {
+        let toml = r#"
+            name = "Test Merchant"
+            base_url = "https://api.test.com"
+            api_prefix = "/api/v2"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.name, "Test Merchant");
+        assert_eq!(config.base_url, "https://api.test.com");
+        assert_eq!(config.api_prefix, "/api/v2");
+    }
+
+    #[test]
+    fn test_endpoint_config_from_toml() {
+        let toml = r#"
+            name = "Test"
+            base_url = "https://test.com"
+
+            [endpoints]
+            products = "/catalog"
+            product = "/catalog/{id}"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.endpoints.products.as_ref().unwrap(), "/catalog");
+        assert_eq!(config.endpoints.product.as_ref().unwrap(), "/catalog/{id}");
+    }
+
+    #[test]
+    fn test_field_mappings_from_toml() {
+        let toml = r#"
+            name = "Test"
+            base_url = "https://test.com"
+
+            [field_mappings.request]
+            consumer_id = "customerId"
+            product_id = "sku"
+
+            [field_mappings.response]
+            customerId = "consumer_id"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert_eq!(&config.field_mappings.request["consumer_id"], "customerId");
+        assert_eq!(&config.field_mappings.response["customerId"], "consumer_id");
+    }
+
+    #[test]
+    fn test_auth_config_api_key() {
+        let toml = r#"
+            name = "Test"
+            base_url = "https://test.com"
+
+            [auth]
+            type = "api_key"
+            header = "X-API-Key"
+            env_var = "MERCHANT_API_KEY"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        let Some(AuthConfig::ApiKey { header, env_var }) = config.auth else {
+            unreachable!("expected ApiKey auth config")
+        };
+        assert_eq!(header, "X-API-Key");
+        assert_eq!(env_var, "MERCHANT_API_KEY");
+    }
+
+    #[test]
+    fn test_auth_config_bearer() {
+        let toml = r#"
+            name = "Test"
+            base_url = "https://test.com"
+
+            [auth]
+            type = "bearer"
+            env_var = "BEARER_TOKEN"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        let Some(AuthConfig::Bearer { env_var }) = config.auth else {
+            unreachable!("expected Bearer auth config")
+        };
+        assert_eq!(env_var, "BEARER_TOKEN");
+    }
+
+    #[test]
+    fn test_pagination_style() {
+        let toml = r#"
+            name = "Test"
+            base_url = "https://test.com"
+            pagination = "offset_based"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert!(matches!(config.pagination, PaginationStyle::OffsetBased));
+    }
+
+    #[test]
+    fn test_pagination_style_default() {
+        let toml = r#"
+            name = "Test"
+            base_url = "https://test.com"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert!(matches!(config.pagination, PaginationStyle::PageBased));
+    }
+
+    #[test]
+    fn test_complete_config() {
+        let toml = r#"
+            name = "ACME Store"
+            base_url = "https://api.acme.com"
+            api_prefix = "/api/v2"
+            pagination = "offset_based"
+
+            [endpoints]
+            products = "/catalog"
+            product = "/catalog/{id}"
+            cart = "/basket"
+            add_to_cart = "/basket/add"
+
+            [field_mappings.request]
+            consumer_id = "customerId"
+            product_id = "sku"
+
+            [field_mappings.response]
+            customerId = "consumer_id"
+            sku = "product_id"
+
+            [auth]
+            type = "api_key"
+            header = "X-ACME-Key"
+            env_var = "ACME_API_KEY"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.name, "ACME Store");
+        assert_eq!(config.api_prefix, "/api/v2");
+        assert!(config.endpoints.products.is_some());
+        assert!(config.field_mappings.request.contains_key("consumer_id"));
+        assert!(config.auth.is_some());
+        assert!(matches!(config.pagination, PaginationStyle::OffsetBased));
+    }
+
+    #[test]
+    fn test_auth_config_oauth2() {
+        let toml = r#"
+            name = "OAuth Merchant"
+            base_url = "https://test.com"
+
+            [auth]
+            type = "o_auth2"
+            token_url = "https://auth.test.com/token"
+            client_id_env = "CLIENT_ID"
+            client_secret_env = "CLIENT_SECRET"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        let Some(AuthConfig::OAuth2 { token_url, client_id_env, client_secret_env }) = config.auth
+        else {
+            unreachable!("expected OAuth2 auth config")
+        };
+        assert_eq!(token_url, "https://auth.test.com/token");
+        assert_eq!(client_id_env, "CLIENT_ID");
+        assert_eq!(client_secret_env, "CLIENT_SECRET");
+    }
+
+    #[test]
+    fn test_invalid_toml_syntax() {
+        let toml = "name = unclosed string";
+        let result: std::result::Result<MerchantConfig, _> = toml::from_str(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_required_name() {
+        let toml = r#"
+            base_url = "https://test.com"
+        "#;
+        let result: std::result::Result<MerchantConfig, _> = toml::from_str(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_required_base_url() {
+        let toml = r#"
+            name = "Test"
+        "#;
+        let result: std::result::Result<MerchantConfig, _> = toml::from_str(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_field_mappings() {
+        let config = FieldMappingConfig::default();
+        assert!(config.request.is_empty());
+        assert!(config.response.is_empty());
+    }
+
+    #[test]
+    fn test_endpoint_config_default() {
+        let config = EndpointConfig::default();
+        assert!(config.products.is_none());
+        assert!(config.product.is_none());
+        assert!(config.cart.is_none());
+    }
+
+    #[test]
+    fn test_pagination_cursor_based() {
+        let toml = r#"
+            name = "Test"
+            base_url = "https://test.com"
+            pagination = "cursor_based"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert!(matches!(config.pagination, PaginationStyle::CursorBased));
+    }
+
+    #[test]
+    fn test_empty_api_prefix_default() {
+        let config = MerchantConfig::default();
+        assert_eq!(config.api_prefix, "");
+    }
+
+    #[test]
+    fn test_none_auth_config() {
+        let config = MerchantConfig::default();
+        assert!(config.auth.is_none());
+    }
+
+    #[test]
+    fn test_all_endpoints_configured() {
+        let toml = r#"
+            name = "Full Endpoints"
+            base_url = "https://test.com"
+
+            [endpoints]
+            products = "/p"
+            product = "/p/{id}"
+            cart = "/c"
+            add_to_cart = "/c/add"
+            cart_item = "/c/i/{id}"
+            orders = "/o"
+            order = "/o/{id}"
+            checkout = "/ch"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert!(config.endpoints.products.is_some());
+        assert!(config.endpoints.product.is_some());
+        assert!(config.endpoints.cart.is_some());
+        assert!(config.endpoints.add_to_cart.is_some());
+        assert!(config.endpoints.cart_item.is_some());
+        assert!(config.endpoints.orders.is_some());
+        assert!(config.endpoints.order.is_some());
+        assert!(config.endpoints.checkout.is_some());
+    }
+
+    // Security validation tests
+
+    #[test]
+    fn test_validate_valid_config() {
+        let toml = r#"
+            name = "Valid Config"
+            base_url = "https://api.example.com"
+
+            [endpoints]
+            products = "/catalog"
+            product = "/catalog/{id}"
+        "#;
+
+        let config: MerchantConfig = toml::from_str(toml).unwrap();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_http_base_url_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "http://api.example.com".to_owned(),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("HTTPS"));
+    }
+
+    #[test]
+    fn test_validate_localhost_base_url_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://localhost/api".to_owned(),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("localhost"));
+    }
+
+    #[test]
+    fn test_validate_loopback_base_url_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://127.0.0.1/api".to_owned(),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_path_traversal_endpoint_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            endpoints: EndpointConfig {
+                products: Some("/../../../etc/passwd".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("path traversal"));
+    }
+
+    #[test]
+    fn test_validate_double_slash_endpoint_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            endpoints: EndpointConfig {
+                products: Some("//evil.com/products".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("double slash"));
+    }
+
+    #[test]
+    fn test_validate_endpoint_must_start_with_slash() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            endpoints: EndpointConfig {
+                products: Some("products".to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("must start with '/'"));
+    }
+
+    #[test]
+    fn test_validate_prototype_pollution_field_rejected() {
+        let mut request = HashMap::new();
+        request.insert("__proto__".to_owned(), "malicious".to_owned());
+
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            field_mappings: FieldMappingConfig { request, response: HashMap::new() },
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("forbidden name"));
+    }
+
+    #[test]
+    fn test_validate_null_byte_field_rejected() {
+        let mut request = HashMap::new();
+        request.insert("field\0name".to_owned(), "value".to_owned());
+
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            field_mappings: FieldMappingConfig { request, response: HashMap::new() },
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("null byte"));
+    }
+
+    #[test]
+    fn test_validate_env_var_name_invalid_chars() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::ApiKey {
+                header: "X-API-Key".to_owned(),
+                env_var: "MY-ENV-VAR".to_owned(), // Invalid: contains hyphen
+            }),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("invalid character"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_http_token_url_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::OAuth2 {
+                token_url: "http://auth.example.com/token".to_owned(),
+                client_id_env: "CLIENT_ID".to_owned(),
+                client_secret_env: "CLIENT_SECRET".to_owned(),
+            }),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("HTTPS"));
+    }
+
+    #[test]
+    fn test_validate_oauth2_localhost_token_url_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::OAuth2 {
+                token_url: "https://localhost/token".to_owned(),
+                client_id_env: "CLIENT_ID".to_owned(),
+                client_secret_env: "CLIENT_SECRET".to_owned(),
+            }),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("localhost"));
+    }
+
+    #[test]
+    fn test_validate_header_name_invalid_chars() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::ApiKey {
+                header: "X-API:Key".to_owned(), // Invalid: contains colon
+                env_var: "API_KEY".to_owned(),
+            }),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("invalid character"));
+    }
+
+    #[test]
+    fn test_validate_empty_base_url_allowed() {
+        // Default config has empty base_url, which is allowed
+        let config = MerchantConfig::default();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_valid_auth_configs() {
+        // Valid API Key
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::ApiKey {
+                header: "X-API-Key".to_owned(),
+                env_var: "MY_API_KEY".to_owned(),
+            }),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+
+        // Valid Bearer
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::Bearer { env_var: "BEARER_TOKEN".to_owned() }),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+
+        // Valid OAuth2
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::OAuth2 {
+                token_url: "https://auth.example.com/oauth/token".to_owned(),
+                client_id_env: "OAUTH_CLIENT_ID".to_owned(),
+                client_secret_env: "OAUTH_CLIENT_SECRET".to_owned(),
+            }),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_env_var_starts_with_number_rejected() {
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            auth: Some(AuthConfig::Bearer { env_var: "1_INVALID_VAR".to_owned() }),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("must start with letter"));
+    }
+
+    #[test]
+    fn test_validate_sql_injection_field_rejected() {
+        let mut request = HashMap::new();
+        request.insert("field'; DROP TABLE users-- ".to_owned(), "value".to_owned());
+
+        let config = MerchantConfig {
+            name: "Test".to_owned(),
+            base_url: "https://api.example.com".to_owned(),
+            field_mappings: FieldMappingConfig { request, response: HashMap::new() },
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("SQL pattern"));
+    }
+}

--- a/tap-mcp-bridge/src/merchant/default.rs
+++ b/tap-mcp-bridge/src/merchant/default.rs
@@ -1,0 +1,478 @@
+//! Default merchant implementation.
+//!
+//! This module provides a default merchant implementation using standard TAP conventions.
+
+use std::path::Path;
+
+use crate::{
+    error::{BridgeError, Result},
+    mcp::models,
+    merchant::{
+        ConfigurableEndpointResolver, ConfigurableFieldMapper, EndpointResolver, FieldMapper,
+        MerchantApi, MerchantConfig,
+    },
+};
+
+/// Default merchant implementation using standard TAP conventions.
+///
+/// This implementation provides out-of-box compatibility with merchants
+/// following the standard TAP API specification.
+#[derive(Debug, Clone)]
+pub struct DefaultMerchant {
+    config: MerchantConfig,
+    endpoint_resolver: ConfigurableEndpointResolver,
+    field_mapper: ConfigurableFieldMapper,
+}
+
+impl DefaultMerchant {
+    /// Creates a new default merchant with standard configuration.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_config(MerchantConfig::default())
+    }
+
+    /// Creates a merchant from TOML configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if TOML parsing fails or configuration validation fails.
+    pub fn from_toml(toml_str: &str) -> Result<Self> {
+        let config: MerchantConfig = toml::from_str(toml_str)
+            .map_err(|e| BridgeError::InvalidInput(format!("invalid TOML config: {e}")))?;
+        config.validate()?;
+        Ok(Self::with_config(config))
+    }
+
+    /// Creates a merchant from configuration file path.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if file cannot be read or TOML parsing fails.
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let content = std::fs::read_to_string(path.as_ref())
+            .map_err(|e| BridgeError::InvalidInput(format!("cannot read config file: {e}")))?;
+        Self::from_toml(&content)
+    }
+
+    /// Creates a merchant with the given configuration.
+    #[must_use]
+    pub fn with_config(config: MerchantConfig) -> Self {
+        let endpoint_resolver = ConfigurableEndpointResolver::new(&config.endpoints);
+        let field_mapper = ConfigurableFieldMapper::new(&config.field_mappings);
+        Self { config, endpoint_resolver, field_mapper }
+    }
+
+    /// Returns the merchant configuration.
+    #[must_use]
+    pub fn config(&self) -> &MerchantConfig {
+        &self.config
+    }
+}
+
+impl Default for DefaultMerchant {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MerchantApi for DefaultMerchant {
+    type CartState = models::CartState;
+    type Order = models::Order;
+    type PaymentResult = models::PaymentResult;
+    type Product = models::Product;
+    // For DefaultMerchant, associated types match standard models
+    type ProductCatalog = models::ProductCatalog;
+
+    fn endpoint_resolver(&self) -> &dyn EndpointResolver {
+        &self.endpoint_resolver
+    }
+
+    fn field_mapper(&self) -> &dyn FieldMapper {
+        &self.field_mapper
+    }
+
+    // Conversion is identity for default merchant
+    fn to_standard_catalog(&self, catalog: Self::ProductCatalog) -> Result<models::ProductCatalog> {
+        Ok(catalog)
+    }
+
+    fn to_standard_product(&self, product: Self::Product) -> Result<models::Product> {
+        Ok(product)
+    }
+
+    fn to_standard_cart(&self, cart: Self::CartState) -> Result<models::CartState> {
+        Ok(cart)
+    }
+
+    fn to_standard_order(&self, order: Self::Order) -> Result<models::Order> {
+        Ok(order)
+    }
+
+    fn to_standard_payment(&self, result: Self::PaymentResult) -> Result<models::PaymentResult> {
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unreachable,
+    reason = "test code uses unreachable for expected-path assertions"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_merchant_new() {
+        let merchant = DefaultMerchant::new();
+        assert_eq!(merchant.config().name, "Default Merchant");
+    }
+
+    #[test]
+    fn test_default_merchant_default() {
+        let merchant = DefaultMerchant::default();
+        assert_eq!(merchant.config().name, "Default Merchant");
+    }
+
+    #[test]
+    fn test_default_merchant_from_toml() {
+        let toml = r#"
+            name = "Test Merchant"
+            base_url = "https://api.test.com"
+            api_prefix = "/api/v1"
+        "#;
+
+        let merchant = DefaultMerchant::from_toml(toml).unwrap();
+        assert_eq!(merchant.config().name, "Test Merchant");
+        assert_eq!(merchant.config().base_url, "https://api.test.com");
+        assert_eq!(merchant.config().api_prefix, "/api/v1");
+    }
+
+    #[test]
+    fn test_default_merchant_from_toml_invalid() {
+        let toml = "invalid toml {{{";
+        let result = DefaultMerchant::from_toml(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_default_merchant_with_config() {
+        let config = MerchantConfig {
+            name: "Custom Merchant".to_owned(),
+            base_url: "https://custom.com".to_owned(),
+            ..Default::default()
+        };
+
+        let merchant = DefaultMerchant::with_config(config);
+        assert_eq!(merchant.config().name, "Custom Merchant");
+    }
+
+    #[test]
+    fn test_default_merchant_endpoint_resolver() {
+        let merchant = DefaultMerchant::new();
+        let resolver = merchant.endpoint_resolver();
+        assert_eq!(resolver.checkout_endpoint(), "/checkout");
+    }
+
+    #[test]
+    fn test_default_merchant_field_mapper() {
+        let merchant = DefaultMerchant::new();
+        let mapper = merchant.field_mapper();
+        assert_eq!(mapper.map_request_field("consumer_id"), "consumer_id");
+        assert!(!mapper.has_custom_mappings());
+    }
+
+    #[test]
+    fn test_default_merchant_identity_conversions() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+
+        let merchant = DefaultMerchant::new();
+
+        // Test product catalog conversion (identity)
+        let catalog = models::ProductCatalog { products: vec![], total: 10, page: 1, per_page: 20 };
+        let result = merchant.to_standard_catalog(catalog.clone()).unwrap();
+        assert_eq!(result.total, catalog.total);
+
+        // Test product conversion (identity)
+        let product = models::Product {
+            id: "prod-123".to_owned(),
+            name: "Test Product".to_owned(),
+            description: "A test product".to_owned(),
+            price: Decimal::new(1999, 2),
+            currency: "USD".to_owned(),
+            images: vec![],
+            variants: vec![],
+            inventory: Some(100),
+        };
+        let result = merchant.to_standard_product(product.clone()).unwrap();
+        assert_eq!(result.id, product.id);
+
+        // Test cart conversion (identity)
+        let cart = models::CartState {
+            cart_id: "cart-456".to_owned(),
+            items: vec![],
+            subtotal: Decimal::new(5000, 2),
+            tax: Decimal::new(400, 2),
+            shipping: None,
+            total: Decimal::new(5400, 2),
+            currency: "USD".to_owned(),
+        };
+        let result = merchant.to_standard_cart(cart.clone()).unwrap();
+        assert_eq!(result.cart_id, cart.cart_id);
+
+        // Test order conversion (identity)
+        let address = models::Address {
+            name: "John Doe".to_owned(),
+            street: "123 Main St".to_owned(),
+            city: "San Francisco".to_owned(),
+            state: "CA".to_owned(),
+            postal_code: "94102".to_owned(),
+            country: "US".to_owned(),
+            phone: None,
+        };
+        let order = models::Order {
+            order_id: "order-789".to_owned(),
+            status: models::OrderStatus::Pending,
+            items: vec![],
+            subtotal: Decimal::new(10000, 2),
+            tax: Decimal::new(850, 2),
+            shipping: Decimal::new(500, 2),
+            total: Decimal::new(11350, 2),
+            currency: "USD".to_owned(),
+            shipping_address: address.clone(),
+            billing_address: address,
+            created_at: Utc::now(),
+        };
+        let result = merchant.to_standard_order(order.clone()).unwrap();
+        assert_eq!(result.order_id, order.order_id);
+
+        // Test payment result conversion (identity)
+        let payment = models::PaymentResult {
+            transaction_id: "txn-abc".to_owned(),
+            status: models::PaymentStatus::Approved,
+            order_id: "order-789".to_owned(),
+            amount: Decimal::new(11350, 2),
+            currency: "USD".to_owned(),
+            message: Some("Payment successful".to_owned()),
+        };
+        let result = merchant.to_standard_payment(payment.clone()).unwrap();
+        assert_eq!(result.transaction_id, payment.transaction_id);
+    }
+
+    #[test]
+    fn test_default_merchant_with_custom_endpoints() {
+        use crate::merchant::traits::ProductQueryParams;
+
+        let toml = r#"
+            name = "Custom Endpoints Merchant"
+            base_url = "https://merchant.com"
+
+            [endpoints]
+            products = "/catalog"
+            product = "/catalog/{id}"
+        "#;
+
+        let merchant = DefaultMerchant::from_toml(toml).unwrap();
+        let resolver = merchant.endpoint_resolver();
+
+        let params = ProductQueryParams::default();
+        assert_eq!(resolver.products_endpoint(&params), "/catalog");
+        assert_eq!(resolver.product_endpoint("sku-123"), "/catalog/sku-123");
+    }
+
+    #[test]
+    fn test_default_merchant_with_field_mappings() {
+        let toml = r#"
+            name = "Field Mapping Merchant"
+            base_url = "https://merchant.com"
+
+            [field_mappings.request]
+            consumer_id = "customerId"
+            product_id = "sku"
+
+            [field_mappings.response]
+            customerId = "consumer_id"
+        "#;
+
+        let merchant = DefaultMerchant::from_toml(toml).unwrap();
+        let mapper = merchant.field_mapper();
+
+        assert_eq!(mapper.map_request_field("consumer_id"), "customerId");
+        assert_eq!(mapper.map_request_field("product_id"), "sku");
+        assert_eq!(mapper.map_response_field("customerId"), "consumer_id");
+        assert!(mapper.has_custom_mappings());
+    }
+
+    #[test]
+    fn test_default_merchant_from_file_not_found() {
+        let result = DefaultMerchant::from_file("/nonexistent/path/config.toml");
+        let Err(BridgeError::InvalidInput(msg)) = result else {
+            unreachable!("expected InvalidInput error")
+        };
+        assert!(msg.contains("cannot read config file"));
+    }
+
+    #[test]
+    fn test_default_merchant_from_toml_empty() {
+        let toml = "";
+        let result = DefaultMerchant::from_toml(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_default_merchant_from_toml_missing_name() {
+        let toml = r#"
+            base_url = "https://test.com"
+        "#;
+        let result = DefaultMerchant::from_toml(toml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_default_merchant_config_accessor() {
+        let config = MerchantConfig {
+            name: "Test Config".to_owned(),
+            base_url: "https://test.com".to_owned(),
+            ..Default::default()
+        };
+        let merchant = DefaultMerchant::with_config(config.clone());
+
+        assert_eq!(merchant.config().name, "Test Config");
+        assert_eq!(merchant.config().base_url, "https://test.com");
+    }
+
+    #[test]
+    fn test_default_merchant_no_transformers() {
+        let merchant = DefaultMerchant::new();
+        assert!(merchant.request_transformer().is_none());
+        assert!(merchant.response_transformer().is_none());
+    }
+
+    #[test]
+    fn test_default_merchant_clone() {
+        let merchant = DefaultMerchant::new();
+        let cloned = merchant.clone();
+        assert_eq!(merchant.config().name, cloned.config().name);
+    }
+
+    #[test]
+    fn test_default_merchant_minimal_config() {
+        let toml = r#"
+            name = "Minimal"
+            base_url = "https://minimal.com"
+        "#;
+
+        let merchant = DefaultMerchant::from_toml(toml).unwrap();
+        assert_eq!(merchant.config().name, "Minimal");
+        assert_eq!(merchant.config().api_prefix, "");
+        assert!(merchant.config().auth.is_none());
+    }
+
+    #[test]
+    fn test_default_merchant_with_all_auth_types() {
+        let toml_api_key = r#"
+            name = "Test"
+            base_url = "https://test.com"
+
+            [auth]
+            type = "api_key"
+            header = "X-API-Key"
+            env_var = "API_KEY"
+        "#;
+        let merchant = DefaultMerchant::from_toml(toml_api_key).unwrap();
+        assert!(merchant.config().auth.is_some());
+
+        let toml_bearer = r#"
+            name = "Test"
+            base_url = "https://test.com"
+
+            [auth]
+            type = "bearer"
+            env_var = "BEARER_TOKEN"
+        "#;
+        let merchant = DefaultMerchant::from_toml(toml_bearer).unwrap();
+        assert!(merchant.config().auth.is_some());
+
+        let toml_oauth2 = r#"
+            name = "Test"
+            base_url = "https://test.com"
+
+            [auth]
+            type = "o_auth2"
+            token_url = "https://auth.test.com/token"
+            client_id_env = "CLIENT_ID"
+            client_secret_env = "CLIENT_SECRET"
+        "#;
+        let merchant = DefaultMerchant::from_toml(toml_oauth2).unwrap();
+        assert!(merchant.config().auth.is_some());
+    }
+
+    #[test]
+    fn test_default_merchant_identity_conversion_with_empty_collections() {
+        let merchant = DefaultMerchant::new();
+
+        let catalog = models::ProductCatalog { products: vec![], total: 0, page: 1, per_page: 20 };
+        let result = merchant.to_standard_catalog(catalog.clone()).unwrap();
+        assert!(result.products.is_empty());
+
+        let cart = models::CartState {
+            cart_id: "empty".to_owned(),
+            items: vec![],
+            subtotal: rust_decimal::Decimal::ZERO,
+            tax: rust_decimal::Decimal::ZERO,
+            shipping: None,
+            total: rust_decimal::Decimal::ZERO,
+            currency: "USD".to_owned(),
+        };
+        let result = merchant.to_standard_cart(cart.clone()).unwrap();
+        assert!(result.items.is_empty());
+    }
+
+    #[test]
+    fn test_default_merchant_with_unicode_config() {
+        let toml = r#"
+            name = "测试商家"
+            base_url = "https://测试.com"
+            api_prefix = "/api/v1"
+        "#;
+
+        let merchant = DefaultMerchant::from_toml(toml).unwrap();
+        assert_eq!(merchant.config().name, "测试商家");
+    }
+
+    #[test]
+    fn test_default_merchant_with_all_pagination_styles() {
+        let toml_page = r#"
+            name = "Test"
+            base_url = "https://test.com"
+            pagination = "page_based"
+        "#;
+        let merchant = DefaultMerchant::from_toml(toml_page).unwrap();
+        assert!(matches!(
+            merchant.config().pagination,
+            crate::merchant::PaginationStyle::PageBased
+        ));
+
+        let toml_offset = r#"
+            name = "Test"
+            base_url = "https://test.com"
+            pagination = "offset_based"
+        "#;
+        let merchant = DefaultMerchant::from_toml(toml_offset).unwrap();
+        assert!(matches!(
+            merchant.config().pagination,
+            crate::merchant::PaginationStyle::OffsetBased
+        ));
+
+        let toml_cursor = r#"
+            name = "Test"
+            base_url = "https://test.com"
+            pagination = "cursor_based"
+        "#;
+        let merchant = DefaultMerchant::from_toml(toml_cursor).unwrap();
+        assert!(matches!(
+            merchant.config().pagination,
+            crate::merchant::PaginationStyle::CursorBased
+        ));
+    }
+}

--- a/tap-mcp-bridge/src/merchant/endpoint.rs
+++ b/tap-mcp-bridge/src/merchant/endpoint.rs
@@ -1,0 +1,321 @@
+//! Endpoint resolution implementations.
+//!
+//! This module provides endpoint resolvers for merchant APIs.
+
+use crate::merchant::{EndpointConfig, EndpointResolver, traits::ProductQueryParams};
+
+/// Default endpoint resolver using standard TAP paths.
+#[derive(Debug, Clone)]
+pub struct DefaultEndpointResolver;
+
+impl Default for DefaultEndpointResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DefaultEndpointResolver {
+    /// Creates a new default endpoint resolver.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl EndpointResolver for DefaultEndpointResolver {
+    fn products_endpoint(&self, _params: &ProductQueryParams) -> String {
+        "/products".to_owned()
+    }
+
+    fn product_endpoint(&self, product_id: &str) -> String {
+        format!("/products/{product_id}")
+    }
+
+    fn cart_endpoint(&self, _cart_id: &str) -> String {
+        "/cart".to_owned()
+    }
+
+    fn add_to_cart_endpoint(&self) -> String {
+        "/cart/add".to_owned()
+    }
+
+    fn update_cart_item_endpoint(&self, item_id: &str) -> String {
+        format!("/cart/items/{item_id}")
+    }
+
+    fn remove_cart_item_endpoint(&self, item_id: &str) -> String {
+        format!("/cart/items/{item_id}")
+    }
+
+    fn create_order_endpoint(&self) -> String {
+        "/orders".to_owned()
+    }
+
+    fn order_endpoint(&self, order_id: &str) -> String {
+        format!("/orders/{order_id}")
+    }
+
+    fn checkout_endpoint(&self) -> String {
+        "/checkout".to_owned()
+    }
+}
+
+/// Configurable endpoint resolver using merchant configuration.
+#[derive(Debug, Clone)]
+pub struct ConfigurableEndpointResolver {
+    config: EndpointConfig,
+}
+
+impl ConfigurableEndpointResolver {
+    /// Creates a new configurable endpoint resolver.
+    #[must_use]
+    pub fn new(config: &EndpointConfig) -> Self {
+        Self { config: config.clone() }
+    }
+}
+
+impl EndpointResolver for ConfigurableEndpointResolver {
+    fn products_endpoint(&self, _params: &ProductQueryParams) -> String {
+        self.config
+            .products
+            .as_ref()
+            .map_or_else(|| "/products".to_owned(), Clone::clone)
+    }
+
+    fn product_endpoint(&self, product_id: &str) -> String {
+        self.config.product.as_ref().map_or_else(
+            || format!("/products/{product_id}"),
+            |template| template.replace("{id}", product_id),
+        )
+    }
+
+    fn cart_endpoint(&self, _cart_id: &str) -> String {
+        self.config.cart.as_ref().map_or_else(|| "/cart".to_owned(), Clone::clone)
+    }
+
+    fn add_to_cart_endpoint(&self) -> String {
+        self.config
+            .add_to_cart
+            .as_ref()
+            .map_or_else(|| "/cart/add".to_owned(), Clone::clone)
+    }
+
+    fn update_cart_item_endpoint(&self, item_id: &str) -> String {
+        self.config.cart_item.as_ref().map_or_else(
+            || format!("/cart/items/{item_id}"),
+            |template| template.replace("{id}", item_id),
+        )
+    }
+
+    fn remove_cart_item_endpoint(&self, item_id: &str) -> String {
+        self.config.cart_item.as_ref().map_or_else(
+            || format!("/cart/items/{item_id}"),
+            |template| template.replace("{id}", item_id),
+        )
+    }
+
+    fn create_order_endpoint(&self) -> String {
+        self.config.orders.as_ref().map_or_else(|| "/orders".to_owned(), Clone::clone)
+    }
+
+    fn order_endpoint(&self, order_id: &str) -> String {
+        self.config.order.as_ref().map_or_else(
+            || format!("/orders/{order_id}"),
+            |template| template.replace("{id}", order_id),
+        )
+    }
+
+    fn checkout_endpoint(&self) -> String {
+        self.config
+            .checkout
+            .as_ref()
+            .map_or_else(|| "/checkout".to_owned(), Clone::clone)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_endpoint_resolver() {
+        let resolver = DefaultEndpointResolver::new();
+        let params = ProductQueryParams::default();
+
+        assert_eq!(resolver.products_endpoint(&params), "/products");
+        assert_eq!(resolver.product_endpoint("prod-123"), "/products/prod-123");
+        assert_eq!(resolver.cart_endpoint("cart-456"), "/cart");
+        assert_eq!(resolver.add_to_cart_endpoint(), "/cart/add");
+        assert_eq!(resolver.update_cart_item_endpoint("item-789"), "/cart/items/item-789");
+        assert_eq!(resolver.remove_cart_item_endpoint("item-999"), "/cart/items/item-999");
+        assert_eq!(resolver.create_order_endpoint(), "/orders");
+        assert_eq!(resolver.order_endpoint("order-111"), "/orders/order-111");
+        assert_eq!(resolver.checkout_endpoint(), "/checkout");
+    }
+
+    #[test]
+    fn test_configurable_endpoint_resolver_defaults() {
+        let config = EndpointConfig::default();
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        let params = ProductQueryParams::default();
+
+        assert_eq!(resolver.products_endpoint(&params), "/products");
+        assert_eq!(resolver.product_endpoint("prod-123"), "/products/prod-123");
+    }
+
+    #[test]
+    fn test_configurable_endpoint_resolver_custom() {
+        let config = EndpointConfig {
+            products: Some("/api/catalog".to_owned()),
+            product: Some("/api/catalog/{id}".to_owned()),
+            cart: Some("/basket".to_owned()),
+            add_to_cart: Some("/basket/add".to_owned()),
+            cart_item: Some("/basket/items/{id}".to_owned()),
+            orders: Some("/purchases".to_owned()),
+            order: Some("/purchases/{id}".to_owned()),
+            checkout: Some("/payment".to_owned()),
+        };
+
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        let params = ProductQueryParams::default();
+
+        assert_eq!(resolver.products_endpoint(&params), "/api/catalog");
+        assert_eq!(resolver.product_endpoint("sku-789"), "/api/catalog/sku-789");
+        assert_eq!(resolver.cart_endpoint("cart-123"), "/basket");
+        assert_eq!(resolver.add_to_cart_endpoint(), "/basket/add");
+        assert_eq!(resolver.update_cart_item_endpoint("item-456"), "/basket/items/item-456");
+        assert_eq!(resolver.remove_cart_item_endpoint("item-999"), "/basket/items/item-999");
+        assert_eq!(resolver.create_order_endpoint(), "/purchases");
+        assert_eq!(resolver.order_endpoint("order-abc"), "/purchases/order-abc");
+        assert_eq!(resolver.checkout_endpoint(), "/payment");
+    }
+
+    #[test]
+    fn test_configurable_endpoint_resolver_partial() {
+        let config = EndpointConfig { products: Some("/catalog".to_owned()), ..Default::default() };
+
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        let params = ProductQueryParams::default();
+
+        assert_eq!(resolver.products_endpoint(&params), "/catalog");
+        assert_eq!(resolver.product_endpoint("prod-123"), "/products/prod-123");
+    }
+
+    #[test]
+    fn test_template_substitution() {
+        let config = EndpointConfig {
+            product: Some("/items/{id}/details".to_owned()),
+            ..Default::default()
+        };
+
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        assert_eq!(resolver.product_endpoint("xyz"), "/items/xyz/details");
+    }
+
+    #[test]
+    fn test_default_endpoint_resolver_default_trait() {
+        let resolver = <DefaultEndpointResolver as Default>::default();
+        assert_eq!(resolver.checkout_endpoint(), "/checkout");
+    }
+
+    #[test]
+    fn test_product_endpoint_with_special_characters() {
+        let resolver = DefaultEndpointResolver::new();
+        assert_eq!(resolver.product_endpoint("prod-123_abc.xyz"), "/products/prod-123_abc.xyz");
+    }
+
+    #[test]
+    fn test_product_endpoint_with_unicode() {
+        let resolver = DefaultEndpointResolver::new();
+        assert_eq!(resolver.product_endpoint("产品-123"), "/products/产品-123");
+    }
+
+    #[test]
+    fn test_empty_product_id() {
+        let resolver = DefaultEndpointResolver::new();
+        assert_eq!(resolver.product_endpoint(""), "/products/");
+    }
+
+    #[test]
+    fn test_empty_cart_id() {
+        let resolver = DefaultEndpointResolver::new();
+        assert_eq!(resolver.cart_endpoint(""), "/cart");
+    }
+
+    #[test]
+    fn test_empty_order_id() {
+        let resolver = DefaultEndpointResolver::new();
+        assert_eq!(resolver.order_endpoint(""), "/orders/");
+    }
+
+    #[test]
+    fn test_configurable_multiple_template_placeholders() {
+        let config = EndpointConfig {
+            product: Some("/api/{id}/details/{id}".to_owned()),
+            ..Default::default()
+        };
+
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        assert_eq!(resolver.product_endpoint("xyz"), "/api/xyz/details/xyz");
+    }
+
+    #[test]
+    fn test_configurable_no_template_placeholder() {
+        let config =
+            EndpointConfig { product: Some("/static-product".to_owned()), ..Default::default() };
+
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        assert_eq!(resolver.product_endpoint("ignored"), "/static-product");
+    }
+
+    #[test]
+    fn test_configurable_template_with_special_chars() {
+        let config = EndpointConfig {
+            product: Some("/items/{id}?format=json".to_owned()),
+            ..Default::default()
+        };
+
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        assert_eq!(resolver.product_endpoint("123"), "/items/123?format=json");
+    }
+
+    #[test]
+    fn test_update_cart_item_with_empty_id() {
+        let resolver = DefaultEndpointResolver::new();
+        assert_eq!(resolver.update_cart_item_endpoint(""), "/cart/items/");
+    }
+
+    #[test]
+    fn test_remove_cart_item_with_long_id() {
+        let resolver = DefaultEndpointResolver::new();
+        let long_id = "a".repeat(1000);
+        assert_eq!(resolver.remove_cart_item_endpoint(&long_id), format!("/cart/items/{long_id}"));
+    }
+
+    #[test]
+    fn test_all_endpoints_with_same_resolver() {
+        let resolver = DefaultEndpointResolver::new();
+        let params = ProductQueryParams::default();
+
+        // Verify all methods work with same resolver instance
+        let _ = resolver.products_endpoint(&params);
+        let _ = resolver.product_endpoint("1");
+        let _ = resolver.cart_endpoint("2");
+        let _ = resolver.add_to_cart_endpoint();
+        let _ = resolver.update_cart_item_endpoint("3");
+        let _ = resolver.remove_cart_item_endpoint("4");
+        let _ = resolver.create_order_endpoint();
+        let _ = resolver.order_endpoint("5");
+        let _ = resolver.checkout_endpoint();
+    }
+
+    #[test]
+    fn test_configurable_clone() {
+        let config = EndpointConfig { products: Some("/catalog".to_owned()), ..Default::default() };
+        let resolver = ConfigurableEndpointResolver::new(&config);
+        let cloned = resolver.clone();
+
+        let params = ProductQueryParams::default();
+        assert_eq!(resolver.products_endpoint(&params), cloned.products_endpoint(&params));
+    }
+}

--- a/tap-mcp-bridge/src/merchant/field_map.rs
+++ b/tap-mcp-bridge/src/merchant/field_map.rs
@@ -1,0 +1,354 @@
+//! Field mapping implementations.
+//!
+//! This module provides field mappers for translating between standard and merchant-specific
+//! field names.
+
+use std::{borrow::Cow, collections::HashMap};
+
+use crate::merchant::{FieldMapper, FieldMappingConfig};
+
+/// Identity field mapper (no transformation).
+#[derive(Debug, Clone)]
+pub struct IdentityFieldMapper;
+
+impl Default for IdentityFieldMapper {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IdentityFieldMapper {
+    /// Creates a new identity field mapper.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl FieldMapper for IdentityFieldMapper {
+    fn map_request_field<'a>(&self, standard_name: &'a str) -> Cow<'a, str> {
+        Cow::Borrowed(standard_name)
+    }
+
+    fn map_response_field<'a>(&self, merchant_name: &'a str) -> Cow<'a, str> {
+        Cow::Borrowed(merchant_name)
+    }
+
+    fn has_custom_mappings(&self) -> bool {
+        false
+    }
+}
+
+/// Configurable field mapper using merchant configuration.
+#[derive(Debug, Clone, Default)]
+pub struct ConfigurableFieldMapper {
+    request_mappings: HashMap<String, String>,
+    response_mappings: HashMap<String, String>,
+}
+
+impl ConfigurableFieldMapper {
+    /// Creates a new configurable field mapper.
+    #[must_use]
+    pub fn new(config: &FieldMappingConfig) -> Self {
+        Self {
+            request_mappings: config.request.clone(),
+            response_mappings: config.response.clone(),
+        }
+    }
+
+    /// Returns true if this mapper has any custom mappings.
+    #[must_use]
+    pub fn has_mappings(&self) -> bool {
+        !self.request_mappings.is_empty() || !self.response_mappings.is_empty()
+    }
+}
+
+impl FieldMapper for ConfigurableFieldMapper {
+    fn map_request_field<'a>(&self, standard_name: &'a str) -> Cow<'a, str> {
+        self.request_mappings
+            .get(standard_name)
+            .map_or_else(|| Cow::Borrowed(standard_name), |s| Cow::Owned(s.clone()))
+    }
+
+    fn map_response_field<'a>(&self, merchant_name: &'a str) -> Cow<'a, str> {
+        self.response_mappings
+            .get(merchant_name)
+            .map_or_else(|| Cow::Borrowed(merchant_name), |s| Cow::Owned(s.clone()))
+    }
+
+    fn has_custom_mappings(&self) -> bool {
+        self.has_mappings()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_identity_field_mapper() {
+        let mapper = IdentityFieldMapper::new();
+        assert_eq!(mapper.map_request_field("consumer_id"), "consumer_id");
+        assert_eq!(mapper.map_request_field("product_id"), "product_id");
+        assert_eq!(mapper.map_response_field("consumer_id"), "consumer_id");
+        assert!(!mapper.has_custom_mappings());
+    }
+
+    #[test]
+    fn test_identity_field_mapper_default() {
+        let mapper = <IdentityFieldMapper as Default>::default();
+        assert_eq!(mapper.map_request_field("test"), "test");
+    }
+
+    #[test]
+    fn test_configurable_field_mapper_empty() {
+        let config = FieldMappingConfig::default();
+        let mapper = ConfigurableFieldMapper::new(&config);
+
+        assert_eq!(mapper.map_request_field("consumer_id"), "consumer_id");
+        assert_eq!(mapper.map_response_field("product_id"), "product_id");
+        assert!(!mapper.has_custom_mappings());
+    }
+
+    #[test]
+    fn test_configurable_field_mapper_request_mapping() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("consumer_id".to_owned(), "customerId".to_owned());
+        request_mappings.insert("product_id".to_owned(), "sku".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+
+        assert_eq!(mapper.map_request_field("consumer_id"), "customerId");
+        assert_eq!(mapper.map_request_field("product_id"), "sku");
+        assert_eq!(mapper.map_request_field("unmapped_field"), "unmapped_field");
+        assert!(mapper.has_custom_mappings());
+    }
+
+    #[test]
+    fn test_configurable_field_mapper_response_mapping() {
+        let mut response_mappings = HashMap::new();
+        response_mappings.insert("customerId".to_owned(), "consumer_id".to_owned());
+        response_mappings.insert("sku".to_owned(), "product_id".to_owned());
+
+        let config = FieldMappingConfig { request: HashMap::new(), response: response_mappings };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+
+        assert_eq!(mapper.map_response_field("customerId"), "consumer_id");
+        assert_eq!(mapper.map_response_field("sku"), "product_id");
+        assert_eq!(mapper.map_response_field("unmapped"), "unmapped");
+        assert!(mapper.has_custom_mappings());
+    }
+
+    #[test]
+    fn test_configurable_field_mapper_bidirectional() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("consumer_id".to_owned(), "customerId".to_owned());
+
+        let mut response_mappings = HashMap::new();
+        response_mappings.insert("customerId".to_owned(), "consumer_id".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: response_mappings };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+
+        // Request mapping: standard -> merchant
+        assert_eq!(mapper.map_request_field("consumer_id"), "customerId");
+
+        // Response mapping: merchant -> standard
+        assert_eq!(mapper.map_response_field("customerId"), "consumer_id");
+    }
+
+    #[test]
+    fn test_configurable_field_mapper_multiple_mappings() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("consumer_id".to_owned(), "customer_id".to_owned());
+        request_mappings.insert("product_id".to_owned(), "item_id".to_owned());
+        request_mappings.insert("cart_id".to_owned(), "basket_id".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+
+        assert_eq!(mapper.map_request_field("consumer_id"), "customer_id");
+        assert_eq!(mapper.map_request_field("product_id"), "item_id");
+        assert_eq!(mapper.map_request_field("cart_id"), "basket_id");
+    }
+
+    #[test]
+    fn test_configurable_field_mapper_default() {
+        let mapper = ConfigurableFieldMapper::default();
+        assert!(!mapper.has_custom_mappings());
+        assert_eq!(mapper.map_request_field("test"), "test");
+    }
+
+    #[test]
+    fn test_has_mappings() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("test".to_owned(), "test_mapped".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert!(mapper.has_mappings());
+    }
+
+    #[test]
+    fn test_identity_mapper_with_empty_string() {
+        let mapper = IdentityFieldMapper::new();
+        assert_eq!(mapper.map_request_field(""), "");
+        assert_eq!(mapper.map_response_field(""), "");
+    }
+
+    #[test]
+    fn test_identity_mapper_with_unicode() {
+        let mapper = IdentityFieldMapper::new();
+        assert_eq!(mapper.map_request_field("用户_id"), "用户_id");
+        assert_eq!(mapper.map_response_field("消费者_名称"), "消费者_名称");
+    }
+
+    #[test]
+    fn test_configurable_mapper_with_empty_string_key() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert(String::new(), "empty_key".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert_eq!(mapper.map_request_field(""), "empty_key");
+    }
+
+    #[test]
+    fn test_configurable_mapper_with_empty_string_value() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("field".to_owned(), String::new());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert_eq!(mapper.map_request_field("field"), "");
+    }
+
+    #[test]
+    fn test_configurable_mapper_unicode_field_names() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("用户_id".to_owned(), "userId".to_owned());
+
+        let mut response_mappings = HashMap::new();
+        response_mappings.insert("userId".to_owned(), "用户_id".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: response_mappings };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert_eq!(mapper.map_request_field("用户_id"), "userId");
+        assert_eq!(mapper.map_response_field("userId"), "用户_id");
+    }
+
+    #[test]
+    fn test_configurable_mapper_case_sensitivity() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("consumer_id".to_owned(), "customerId".to_owned());
+        request_mappings.insert("Consumer_ID".to_owned(), "CUSTOMER_ID".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert_eq!(mapper.map_request_field("consumer_id"), "customerId");
+        assert_eq!(mapper.map_request_field("Consumer_ID"), "CUSTOMER_ID");
+        assert_eq!(mapper.map_request_field("CONSUMER_ID"), "CONSUMER_ID");
+    }
+
+    #[test]
+    fn test_configurable_mapper_special_characters() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("field-name".to_owned(), "field_name".to_owned());
+        request_mappings.insert("field.name".to_owned(), "fieldName".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert_eq!(mapper.map_request_field("field-name"), "field_name");
+        assert_eq!(mapper.map_request_field("field.name"), "fieldName");
+    }
+
+    #[test]
+    fn test_configurable_mapper_very_long_field_names() {
+        let long_field = "a".repeat(1000);
+        let long_mapped = "b".repeat(1000);
+
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert(long_field.clone(), long_mapped.clone());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert_eq!(mapper.map_request_field(&long_field), long_mapped);
+    }
+
+    #[test]
+    fn test_configurable_mapper_response_only_mappings() {
+        let mut response_mappings = HashMap::new();
+        response_mappings.insert("merchantField".to_owned(), "standard_field".to_owned());
+
+        let config = FieldMappingConfig { request: HashMap::new(), response: response_mappings };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        assert!(mapper.has_custom_mappings());
+        assert_eq!(mapper.map_response_field("merchantField"), "standard_field");
+        assert_eq!(mapper.map_request_field("any_field"), "any_field");
+    }
+
+    #[test]
+    fn test_configurable_mapper_clone() {
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("test".to_owned(), "mapped".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        let cloned = mapper.clone();
+
+        assert_eq!(mapper.map_request_field("test"), cloned.map_request_field("test"));
+    }
+
+    #[test]
+    fn test_identity_mapper_cow_borrowed() {
+        use std::borrow::Cow;
+
+        let mapper = IdentityFieldMapper::new();
+        let result = mapper.map_request_field("test");
+
+        // Verify it's actually borrowed
+        assert!(matches!(result, Cow::Borrowed(_)), "expected Borrowed, got Owned");
+    }
+
+    #[test]
+    fn test_configurable_mapper_cow_owned_when_mapped() {
+        use std::borrow::Cow;
+
+        let mut request_mappings = HashMap::new();
+        request_mappings.insert("test".to_owned(), "mapped".to_owned());
+
+        let config = FieldMappingConfig { request: request_mappings, response: HashMap::new() };
+
+        let mapper = ConfigurableFieldMapper::new(&config);
+        let result = mapper.map_request_field("test");
+
+        // Verify it's actually owned when mapped
+        assert!(matches!(result, Cow::Owned(_)), "expected Owned, got Borrowed");
+    }
+
+    #[test]
+    fn test_configurable_mapper_cow_borrowed_when_not_mapped() {
+        use std::borrow::Cow;
+
+        let config = FieldMappingConfig::default();
+        let mapper = ConfigurableFieldMapper::new(&config);
+        let result = mapper.map_request_field("unmapped");
+
+        // Verify it's borrowed when not mapped
+        assert!(matches!(result, Cow::Borrowed(_)), "expected Borrowed, got Owned");
+    }
+}

--- a/tap-mcp-bridge/src/merchant/mod.rs
+++ b/tap-mcp-bridge/src/merchant/mod.rs
@@ -1,0 +1,20 @@
+//! Merchant API abstraction layer.
+//!
+//! This module provides flexible integration with different merchant APIs through
+//! a trait-based abstraction system.
+
+pub mod config;
+pub mod default;
+pub mod endpoint;
+pub mod field_map;
+pub mod traits;
+pub mod transform;
+
+pub use config::{AuthConfig, EndpointConfig, FieldMappingConfig, MerchantConfig, PaginationStyle};
+pub use default::DefaultMerchant;
+pub use endpoint::{ConfigurableEndpointResolver, DefaultEndpointResolver};
+pub use field_map::{ConfigurableFieldMapper, IdentityFieldMapper};
+pub use traits::{
+    EndpointResolver, FieldMapper, MerchantApi, RequestTransformer, ResponseTransformer,
+};
+pub use transform::Operation;

--- a/tap-mcp-bridge/src/merchant/traits.rs
+++ b/tap-mcp-bridge/src/merchant/traits.rs
@@ -1,0 +1,205 @@
+//! Core merchant API abstraction traits.
+//!
+//! This module defines the trait interfaces for flexible merchant integration.
+
+use std::borrow::Cow;
+
+use serde::de::DeserializeOwned;
+
+use crate::{error::Result, mcp::models};
+
+/// Abstraction over merchant-specific API behaviors.
+///
+/// This trait enables the bridge to communicate with merchants that have
+/// different API conventions while maintaining type safety.
+///
+/// # Type Parameters
+///
+/// Each associated type represents a merchant's response format for that
+/// operation. For standard TAP merchants, use the default models from
+/// `crate::mcp::models`.
+///
+/// # Implementation Notes
+///
+/// - Implementors MUST ensure response types can deserialize merchant responses
+/// - Field mapping is handled by `FieldMapper` trait
+/// - Endpoint paths are resolved by `EndpointResolver` trait
+pub trait MerchantApi: Send + Sync {
+    /// Product catalog response type.
+    type ProductCatalog: DeserializeOwned + Send;
+
+    /// Single product response type.
+    type Product: DeserializeOwned + Send;
+
+    /// Cart state response type.
+    type CartState: DeserializeOwned + Send;
+
+    /// Order response type.
+    type Order: DeserializeOwned + Send;
+
+    /// Payment result response type.
+    type PaymentResult: DeserializeOwned + Send;
+
+    /// Returns the endpoint resolver for this merchant.
+    fn endpoint_resolver(&self) -> &dyn EndpointResolver;
+
+    /// Returns the field mapper for this merchant.
+    fn field_mapper(&self) -> &dyn FieldMapper;
+
+    /// Returns the request transformer (if any custom transformation needed).
+    fn request_transformer(&self) -> Option<&dyn RequestTransformer> {
+        None
+    }
+
+    /// Returns the response transformer (if any custom transformation needed).
+    fn response_transformer(&self) -> Option<&dyn ResponseTransformer> {
+        None
+    }
+
+    /// Converts this merchant's product catalog to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails due to incompatible data formats.
+    fn to_standard_catalog(&self, catalog: Self::ProductCatalog) -> Result<models::ProductCatalog>;
+
+    /// Converts this merchant's product to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails due to incompatible data formats.
+    fn to_standard_product(&self, product: Self::Product) -> Result<models::Product>;
+
+    /// Converts this merchant's cart state to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails due to incompatible data formats.
+    fn to_standard_cart(&self, cart: Self::CartState) -> Result<models::CartState>;
+
+    /// Converts this merchant's order to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails due to incompatible data formats.
+    fn to_standard_order(&self, order: Self::Order) -> Result<models::Order>;
+
+    /// Converts this merchant's payment result to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails due to incompatible data formats.
+    fn to_standard_payment(&self, result: Self::PaymentResult) -> Result<models::PaymentResult>;
+}
+
+/// Query parameters for product listing.
+#[derive(Debug, Clone, Default)]
+pub struct ProductQueryParams {
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Product category filter.
+    pub category: Option<String>,
+    /// Search query.
+    pub search: Option<String>,
+    /// Page number.
+    pub page: Option<u32>,
+    /// Items per page.
+    pub per_page: Option<u32>,
+}
+
+/// Resolves API endpoint paths for merchant operations.
+///
+/// Different merchants use different URL structures for their APIs.
+/// This trait abstracts endpoint path resolution.
+pub trait EndpointResolver: Send + Sync {
+    /// Resolves the products list endpoint.
+    ///
+    /// # Arguments
+    /// * `params` - Query parameters to include
+    ///
+    /// # Returns
+    /// Full path with query string (e.g., "/api/v1/catalog?limit=20")
+    fn products_endpoint(&self, params: &ProductQueryParams) -> String;
+
+    /// Resolves the single product endpoint.
+    fn product_endpoint(&self, product_id: &str) -> String;
+
+    /// Resolves the cart retrieval endpoint.
+    fn cart_endpoint(&self, cart_id: &str) -> String;
+
+    /// Resolves the add-to-cart endpoint.
+    fn add_to_cart_endpoint(&self) -> String;
+
+    /// Resolves the cart item update endpoint.
+    fn update_cart_item_endpoint(&self, item_id: &str) -> String;
+
+    /// Resolves the cart item removal endpoint.
+    fn remove_cart_item_endpoint(&self, item_id: &str) -> String;
+
+    /// Resolves the order creation endpoint.
+    fn create_order_endpoint(&self) -> String;
+
+    /// Resolves the order retrieval endpoint.
+    fn order_endpoint(&self, order_id: &str) -> String;
+
+    /// Resolves the checkout/payment endpoint.
+    fn checkout_endpoint(&self) -> String;
+}
+
+/// Maps field names between standard TAP format and merchant-specific format.
+///
+/// This trait handles the translation of field names in request and response
+/// bodies. For example, mapping `consumer_id` to `customerId` or `buyer_id`.
+pub trait FieldMapper: Send + Sync {
+    /// Maps a standard field name to merchant-specific name.
+    ///
+    /// # Arguments
+    /// * `standard_name` - The field name in standard TAP format
+    ///
+    /// # Returns
+    /// The merchant-specific field name, or the original if no mapping exists
+    fn map_request_field<'a>(&self, standard_name: &'a str) -> Cow<'a, str>;
+
+    /// Maps a merchant-specific field name to standard name.
+    fn map_response_field<'a>(&self, merchant_name: &'a str) -> Cow<'a, str>;
+
+    /// Returns true if this mapper has any custom mappings.
+    fn has_custom_mappings(&self) -> bool;
+}
+
+/// Transforms outgoing requests before sending to merchant.
+///
+/// Use this trait when requests need structural changes beyond field renaming.
+pub trait RequestTransformer: Send + Sync {
+    /// Transforms a request body before sending.
+    ///
+    /// # Arguments
+    /// * `body` - The JSON value to transform
+    /// * `operation` - The operation type (products, cart, order, payment)
+    ///
+    /// # Returns
+    /// Transformed JSON value ready to send to merchant
+    ///
+    /// # Errors
+    ///
+    /// Returns error if transformation fails due to invalid structure or data.
+    fn transform_request(
+        &self,
+        body: serde_json::Value,
+        operation: crate::merchant::Operation,
+    ) -> Result<serde_json::Value>;
+}
+
+/// Transforms incoming responses after receiving from merchant.
+pub trait ResponseTransformer: Send + Sync {
+    /// Transforms a response body after receiving.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if transformation fails due to invalid structure or data.
+    fn transform_response(
+        &self,
+        body: serde_json::Value,
+        operation: crate::merchant::Operation,
+    ) -> Result<serde_json::Value>;
+}

--- a/tap-mcp-bridge/src/merchant/transform.rs
+++ b/tap-mcp-bridge/src/merchant/transform.rs
@@ -1,0 +1,68 @@
+//! Request/response transformation utilities.
+//!
+//! This module provides types and utilities for transforming requests and responses.
+
+/// Operation type for context in transformations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    /// Get products catalog.
+    GetProducts,
+    /// Get single product.
+    GetProduct,
+    /// Get cart state.
+    GetCart,
+    /// Add item to cart.
+    AddToCart,
+    /// Update cart item quantity.
+    UpdateCartItem,
+    /// Remove item from cart.
+    RemoveCartItem,
+    /// Create order.
+    CreateOrder,
+    /// Get order details.
+    GetOrder,
+    /// Process payment.
+    ProcessPayment,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_operation_equality() {
+        assert_eq!(Operation::GetProducts, Operation::GetProducts);
+        assert_ne!(Operation::GetProducts, Operation::GetProduct);
+    }
+
+    #[test]
+    fn test_operation_all_variants() {
+        let operations = vec![
+            Operation::GetProducts,
+            Operation::GetProduct,
+            Operation::GetCart,
+            Operation::AddToCart,
+            Operation::UpdateCartItem,
+            Operation::RemoveCartItem,
+            Operation::CreateOrder,
+            Operation::GetOrder,
+            Operation::ProcessPayment,
+        ];
+
+        assert_eq!(operations.len(), 9);
+    }
+
+    #[test]
+    fn test_operation_clone() {
+        let op = Operation::AddToCart;
+        let cloned = op;
+        assert_eq!(op, cloned);
+    }
+
+    #[test]
+    fn test_operation_debug() {
+        let op = Operation::GetProducts;
+        let debug_str = format!("{op:?}");
+        assert!(debug_str.contains("GetProducts"));
+    }
+}

--- a/tap-mcp-bridge/src/reliability/retry.rs
+++ b/tap-mcp-bridge/src/reliability/retry.rs
@@ -252,6 +252,10 @@ pub fn is_retryable(error: &BridgeError) -> bool {
         | BridgeError::InvalidInput(_) => false,
         // Don't retry merchant protocol errors
         BridgeError::MerchantError(_) => false,
+        // Don't retry merchant configuration errors
+        BridgeError::MerchantConfigError(_)
+        | BridgeError::FieldMappingError(_)
+        | BridgeError::TransformationError(_) => false,
         // Don't retry security errors
         BridgeError::ReplayAttack | BridgeError::RequestTooOld(_) => false,
         // Don't retry rate limit errors (should implement backoff instead)

--- a/tap-mcp-bridge/tests/merchant_integration_test.rs
+++ b/tap-mcp-bridge/tests/merchant_integration_test.rs
@@ -1,0 +1,328 @@
+//! Integration tests for merchant abstraction layer.
+//!
+//! Tests end-to-end merchant configuration and API integration.
+
+use tap_mcp_bridge::merchant::{
+    ConfigurableEndpointResolver, ConfigurableFieldMapper, DefaultMerchant, EndpointConfig,
+    EndpointResolver, FieldMapper, FieldMappingConfig, MerchantApi, PaginationStyle,
+    traits::ProductQueryParams,
+};
+
+#[test]
+fn test_full_merchant_configuration_flow() {
+    let toml = r#"
+        name = "Integration Test Merchant"
+        base_url = "https://api.testmerchant.com"
+        api_prefix = "/api/v2"
+        pagination = "offset_based"
+
+        [endpoints]
+        products = "/catalog"
+        product = "/catalog/{id}"
+        cart = "/basket"
+        add_to_cart = "/basket/add"
+        cart_item = "/basket/items/{id}"
+        orders = "/purchases"
+        order = "/purchases/{id}"
+        checkout = "/payment"
+
+        [field_mappings.request]
+        consumer_id = "customerId"
+        product_id = "sku"
+        cart_id = "basketId"
+
+        [field_mappings.response]
+        customerId = "consumer_id"
+        sku = "product_id"
+        basketId = "cart_id"
+    "#;
+
+    let merchant = DefaultMerchant::from_toml(toml).expect("should parse valid TOML");
+
+    // Verify configuration
+    assert_eq!(merchant.config().name, "Integration Test Merchant");
+    assert_eq!(merchant.config().base_url, "https://api.testmerchant.com");
+    assert_eq!(merchant.config().api_prefix, "/api/v2");
+    assert!(matches!(merchant.config().pagination, PaginationStyle::OffsetBased));
+
+    // Verify endpoint resolution
+    let resolver = merchant.endpoint_resolver();
+    let params = ProductQueryParams::default();
+    assert_eq!(resolver.products_endpoint(&params), "/catalog");
+    assert_eq!(resolver.product_endpoint("prod-123"), "/catalog/prod-123");
+    assert_eq!(resolver.cart_endpoint("cart-456"), "/basket");
+    assert_eq!(resolver.add_to_cart_endpoint(), "/basket/add");
+    assert_eq!(resolver.update_cart_item_endpoint("item-789"), "/basket/items/item-789");
+    assert_eq!(resolver.create_order_endpoint(), "/purchases");
+    assert_eq!(resolver.order_endpoint("order-111"), "/purchases/order-111");
+    assert_eq!(resolver.checkout_endpoint(), "/payment");
+
+    // Verify field mapping
+    let mapper = merchant.field_mapper();
+    assert_eq!(mapper.map_request_field("consumer_id"), "customerId");
+    assert_eq!(mapper.map_request_field("product_id"), "sku");
+    assert_eq!(mapper.map_request_field("cart_id"), "basketId");
+    assert_eq!(mapper.map_response_field("customerId"), "consumer_id");
+    assert_eq!(mapper.map_response_field("sku"), "product_id");
+    assert_eq!(mapper.map_response_field("basketId"), "cart_id");
+    assert!(mapper.has_custom_mappings());
+}
+
+#[test]
+fn test_merchant_with_minimal_configuration() {
+    let toml = r#"
+        name = "Minimal Merchant"
+        base_url = "https://minimal.com"
+    "#;
+
+    let merchant = DefaultMerchant::from_toml(toml).expect("should parse minimal TOML");
+
+    // Verify defaults are applied
+    assert_eq!(merchant.config().api_prefix, "");
+    assert!(merchant.config().auth.is_none());
+    assert!(matches!(merchant.config().pagination, PaginationStyle::PageBased));
+
+    // Verify default endpoints
+    let resolver = merchant.endpoint_resolver();
+    let params = ProductQueryParams::default();
+    assert_eq!(resolver.products_endpoint(&params), "/products");
+    assert_eq!(resolver.checkout_endpoint(), "/checkout");
+
+    // Verify identity field mapping
+    let mapper = merchant.field_mapper();
+    assert_eq!(mapper.map_request_field("consumer_id"), "consumer_id");
+    assert!(!mapper.has_custom_mappings());
+}
+
+#[test]
+fn test_merchant_endpoint_resolver_integration() {
+    let config = EndpointConfig {
+        products: Some("/api/items".to_owned()),
+        product: Some("/api/items/{id}/details".to_owned()),
+        cart: Some("/api/shopping-cart".to_owned()),
+        add_to_cart: Some("/api/shopping-cart/items".to_owned()),
+        cart_item: Some("/api/shopping-cart/items/{id}".to_owned()),
+        orders: Some("/api/orders".to_owned()),
+        order: Some("/api/orders/{id}".to_owned()),
+        checkout: Some("/api/checkout/process".to_owned()),
+    };
+
+    let resolver = ConfigurableEndpointResolver::new(&config);
+
+    // Test all endpoints with various IDs
+    let params = ProductQueryParams::default();
+    assert_eq!(resolver.products_endpoint(&params), "/api/items");
+    assert_eq!(resolver.product_endpoint("sku-abc-123"), "/api/items/sku-abc-123/details");
+    assert_eq!(resolver.cart_endpoint("cart-xyz"), "/api/shopping-cart");
+    assert_eq!(resolver.add_to_cart_endpoint(), "/api/shopping-cart/items");
+    assert_eq!(
+        resolver.update_cart_item_endpoint("item-456"),
+        "/api/shopping-cart/items/item-456"
+    );
+    assert_eq!(
+        resolver.remove_cart_item_endpoint("item-789"),
+        "/api/shopping-cart/items/item-789"
+    );
+    assert_eq!(resolver.create_order_endpoint(), "/api/orders");
+    assert_eq!(resolver.order_endpoint("order-999"), "/api/orders/order-999");
+    assert_eq!(resolver.checkout_endpoint(), "/api/checkout/process");
+}
+
+#[test]
+fn test_merchant_field_mapper_integration() {
+    let mut request_mappings = std::collections::HashMap::new();
+    request_mappings.insert("consumer_id".to_owned(), "customer_identifier".to_owned());
+    request_mappings.insert("product_id".to_owned(), "item_sku".to_owned());
+    request_mappings.insert("cart_id".to_owned(), "shopping_basket_id".to_owned());
+    request_mappings.insert("order_id".to_owned(), "purchase_number".to_owned());
+
+    let mut response_mappings = std::collections::HashMap::new();
+    response_mappings.insert("customer_identifier".to_owned(), "consumer_id".to_owned());
+    response_mappings.insert("item_sku".to_owned(), "product_id".to_owned());
+    response_mappings.insert("shopping_basket_id".to_owned(), "cart_id".to_owned());
+    response_mappings.insert("purchase_number".to_owned(), "order_id".to_owned());
+
+    let config = FieldMappingConfig { request: request_mappings, response: response_mappings };
+
+    let mapper = ConfigurableFieldMapper::new(&config);
+
+    // Test request mappings
+    assert_eq!(mapper.map_request_field("consumer_id"), "customer_identifier");
+    assert_eq!(mapper.map_request_field("product_id"), "item_sku");
+    assert_eq!(mapper.map_request_field("cart_id"), "shopping_basket_id");
+    assert_eq!(mapper.map_request_field("order_id"), "purchase_number");
+
+    // Test response mappings
+    assert_eq!(mapper.map_response_field("customer_identifier"), "consumer_id");
+    assert_eq!(mapper.map_response_field("item_sku"), "product_id");
+    assert_eq!(mapper.map_response_field("shopping_basket_id"), "cart_id");
+    assert_eq!(mapper.map_response_field("purchase_number"), "order_id");
+
+    // Test unmapped fields (should pass through)
+    assert_eq!(mapper.map_request_field("unmapped"), "unmapped");
+    assert_eq!(mapper.map_response_field("unknown"), "unknown");
+
+    assert!(mapper.has_custom_mappings());
+}
+
+#[test]
+fn test_merchant_with_product_query_params() {
+    let merchant = DefaultMerchant::new();
+    let resolver = merchant.endpoint_resolver();
+
+    let params = ProductQueryParams {
+        consumer_id: "user-123".to_owned(),
+        category: Some("electronics".to_owned()),
+        search: Some("laptop".to_owned()),
+        page: Some(2),
+        per_page: Some(50),
+    };
+
+    // Endpoint resolver should handle params (even if not used in default implementation)
+    let endpoint = resolver.products_endpoint(&params);
+    assert!(!endpoint.is_empty());
+}
+
+#[test]
+fn test_merchant_identity_conversions() {
+    use chrono::Utc;
+    use rust_decimal::Decimal;
+    use tap_mcp_bridge::mcp::models::{
+        Address, CartState, Order, OrderStatus, PaymentResult, PaymentStatus, Product,
+        ProductCatalog,
+    };
+
+    let merchant = DefaultMerchant::new();
+
+    // Test catalog conversion
+    let catalog = ProductCatalog { products: vec![], total: 100, page: 1, per_page: 20 };
+    let converted = merchant
+        .to_standard_catalog(catalog.clone())
+        .expect("conversion should succeed");
+    assert_eq!(converted.total, 100);
+
+    // Test product conversion
+    let product = Product {
+        id: "prod-123".to_owned(),
+        name: "Test Product".to_owned(),
+        description: "Description".to_owned(),
+        price: Decimal::new(9999, 2),
+        currency: "USD".to_owned(),
+        images: vec![],
+        variants: vec![],
+        inventory: Some(50),
+    };
+    let converted = merchant
+        .to_standard_product(product.clone())
+        .expect("conversion should succeed");
+    assert_eq!(converted.id, "prod-123");
+
+    // Test cart conversion
+    let cart = CartState {
+        cart_id: "cart-456".to_owned(),
+        items: vec![],
+        subtotal: Decimal::new(5000, 2),
+        tax: Decimal::new(400, 2),
+        shipping: None,
+        total: Decimal::new(5400, 2),
+        currency: "USD".to_owned(),
+    };
+    let converted = merchant.to_standard_cart(cart.clone()).expect("conversion should succeed");
+    assert_eq!(converted.cart_id, "cart-456");
+
+    // Test order conversion
+    let address = Address {
+        name: "John Doe".to_owned(),
+        street: "123 Main St".to_owned(),
+        city: "San Francisco".to_owned(),
+        state: "CA".to_owned(),
+        postal_code: "94102".to_owned(),
+        country: "US".to_owned(),
+        phone: None,
+    };
+    let order = Order {
+        order_id: "order-789".to_owned(),
+        status: OrderStatus::Pending,
+        items: vec![],
+        subtotal: Decimal::new(10000, 2),
+        tax: Decimal::new(850, 2),
+        shipping: Decimal::new(500, 2),
+        total: Decimal::new(11350, 2),
+        currency: "USD".to_owned(),
+        shipping_address: address.clone(),
+        billing_address: address,
+        created_at: Utc::now(),
+    };
+    let converted = merchant.to_standard_order(order.clone()).expect("conversion should succeed");
+    assert_eq!(converted.order_id, "order-789");
+
+    // Test payment result conversion
+    let payment = PaymentResult {
+        transaction_id: "txn-abc".to_owned(),
+        status: PaymentStatus::Approved,
+        order_id: "order-789".to_owned(),
+        amount: Decimal::new(11350, 2),
+        currency: "USD".to_owned(),
+        message: Some("Payment successful".to_owned()),
+    };
+    let converted = merchant
+        .to_standard_payment(payment.clone())
+        .expect("conversion should succeed");
+    assert_eq!(converted.transaction_id, "txn-abc");
+}
+
+#[test]
+fn test_merchant_config_roundtrip() {
+    let original_toml = r#"
+        name = "Roundtrip Test"
+        base_url = "https://test.com"
+        api_prefix = "/v1"
+        pagination = "cursor_based"
+
+        [endpoints]
+        products = "/items"
+
+        [field_mappings.request]
+        test_field = "mapped_field"
+    "#;
+
+    let merchant = DefaultMerchant::from_toml(original_toml).expect("should parse TOML");
+    let config = merchant.config();
+
+    assert_eq!(config.name, "Roundtrip Test");
+    assert_eq!(config.base_url, "https://test.com");
+    assert_eq!(config.api_prefix, "/v1");
+    assert!(matches!(config.pagination, PaginationStyle::CursorBased));
+    assert_eq!(config.endpoints.products.as_ref().unwrap(), "/items");
+    assert_eq!(&config.field_mappings.request["test_field"], "mapped_field");
+}
+
+#[test]
+fn test_multiple_merchants_isolation() {
+    let toml1 = r#"
+        name = "Merchant 1"
+        base_url = "https://merchant1.com"
+
+        [endpoints]
+        products = "/catalog1"
+    "#;
+
+    let toml2 = r#"
+        name = "Merchant 2"
+        base_url = "https://merchant2.com"
+
+        [endpoints]
+        products = "/catalog2"
+    "#;
+
+    let merchant1 = DefaultMerchant::from_toml(toml1).unwrap();
+    let merchant2 = DefaultMerchant::from_toml(toml2).unwrap();
+
+    // Verify merchants are isolated
+    assert_eq!(merchant1.config().name, "Merchant 1");
+    assert_eq!(merchant2.config().name, "Merchant 2");
+
+    let params = ProductQueryParams::default();
+    assert_eq!(merchant1.endpoint_resolver().products_endpoint(&params), "/catalog1");
+    assert_eq!(merchant2.endpoint_resolver().products_endpoint(&params), "/catalog2");
+}


### PR DESCRIPTION
## Summary

- Implement trait-based merchant API abstraction for diverse merchant integrations
- Add TOML configuration support for declarative merchant setup
- Include comprehensive security validation (path traversal, URL, field injection protection)
- Optimize with OnceLock singleton for DefaultMerchant

## Key Features

| Feature | Description |
|---------|-------------|
| `MerchantApi` trait | Associated types for type-safe response handling |
| `EndpointResolver` | Customizable API path resolution |
| `FieldMapper` | Bidirectional field name transformation |
| TOML Config | Declarative merchant configuration |
| `DefaultMerchant` | Standard TAP conventions implementation |

## Example Usage

```rust
// Use default TAP merchant
let catalog = get_products(&signer, params).await?;

// Use custom merchant from TOML
let merchant = DefaultMerchant::from_toml(r#"
    name = "ACME Store"
    base_url = "https://api.acme.com"
    
    [endpoints]
    products = "/catalog"
    
    [field_mappings.request]
    consumer_id = "customerId"
"#)?;
let catalog = get_products_with(&signer, &merchant, params).await?;
```

## Security

- Path traversal protection in endpoint templates
- HTTPS-only base_url validation
- Field mapping injection prevention
- OAuth2 token URL SSRF protection

## Test Plan

- [x] 419 tests passing (103 new merchant tests)
- [x] Clippy clean with `-D warnings`
- [x] Performance review - OnceLock singleton applied
- [x] Security review - all critical/high issues fixed
- [x] Integration tests for full configuration flow