### PR TITLE
feat(subscriptions): add comprehensive subscription management system

### DIFF
--- a/tap-mcp-bridge/examples/error_handling.rs
+++ b/tap-mcp-bridge/examples/error_handling.rs
@@ -162,6 +162,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Demonstrates comprehensive error handling with recovery guidance.
+#[allow(
+    clippy::too_many_lines,
+    reason = "Example function demonstrating comprehensive error handling patterns"
+)]
 fn handle_checkout_result(result: Result<tap_mcp_bridge::mcp::CheckoutResult, BridgeError>) {
     match result {
         Ok(checkout) => {
@@ -274,6 +278,52 @@ fn handle_checkout_result(result: Result<tap_mcp_bridge::mcp::CheckoutResult, Br
             eprintln!("   ✗ Unsupported protocol: {msg}");
             eprintln!("   → Fix: Enable required feature flags");
             eprintln!("   → Fix: Use a supported transport protocol");
+        }
+
+        // Subscription-related errors
+        Err(BridgeError::InvalidPlanId(msg)) => {
+            eprintln!("   ✗ Invalid plan ID: {msg}");
+            eprintln!("   → Fix: Use only alphanumeric, hyphen, and underscore characters");
+        }
+
+        Err(BridgeError::InvalidSubscriptionId(msg)) => {
+            eprintln!("   ✗ Invalid subscription ID: {msg}");
+            eprintln!("   → Fix: Use only alphanumeric, hyphen, and underscore characters");
+        }
+
+        Err(BridgeError::SubscriptionError(msg)) => {
+            eprintln!("   ✗ Subscription error: {msg}");
+            eprintln!("   → Check subscription state and try again");
+        }
+
+        Err(BridgeError::InvalidStateTransition { current_state, action }) => {
+            eprintln!("   ✗ Invalid state transition: cannot {action} from {current_state}");
+            eprintln!("   → Check subscription current state before operation");
+        }
+
+        Err(BridgeError::UsageError(msg)) => {
+            eprintln!("   ✗ Usage error: {msg}");
+            eprintln!("   → Validate usage quantity and timestamp");
+        }
+
+        Err(BridgeError::ProrationError(msg)) => {
+            eprintln!("   ✗ Proration error: {msg}");
+            eprintln!("   → Check subscription dates and amounts");
+        }
+
+        Err(BridgeError::PaymentMethodChangeError(msg)) => {
+            eprintln!("   ✗ Payment method change error: {msg}");
+            eprintln!("   → Verify payment method details and try again");
+        }
+
+        Err(BridgeError::SubscriptionNotFound(msg)) => {
+            eprintln!("   ✗ Subscription not found: {msg}");
+            eprintln!("   → Verify subscription ID exists");
+        }
+
+        Err(BridgeError::PlanNotFound(msg)) => {
+            eprintln!("   ✗ Plan not found: {msg}");
+            eprintln!("   → Verify plan ID exists and is active");
         }
     }
 }

--- a/tap-mcp-bridge/src/error.rs
+++ b/tap-mcp-bridge/src/error.rs
@@ -281,6 +281,67 @@ pub enum BridgeError {
     /// - The merchant supports the selected protocol
     #[error("Protocol not supported: {0}")]
     UnsupportedProtocol(String),
+
+    /// Invalid subscription plan ID.
+    ///
+    /// This error occurs when a plan ID fails validation.
+    /// Plan IDs must be non-empty and 64 characters or less.
+    #[error("Invalid plan ID: {0}")]
+    InvalidPlanId(String),
+
+    /// Invalid subscription ID.
+    ///
+    /// This error occurs when a subscription ID fails validation.
+    /// Subscription IDs must be non-empty and 64 characters or less.
+    #[error("Invalid subscription ID: {0}")]
+    InvalidSubscriptionId(String),
+
+    /// Subscription operation failed.
+    ///
+    /// This error occurs when a subscription-related operation fails.
+    #[error("Subscription error: {0}")]
+    SubscriptionError(String),
+
+    /// Invalid state transition attempted.
+    ///
+    /// This error occurs when an invalid subscription state transition is attempted.
+    #[error("Invalid subscription state transition: cannot {action} from {current_state}")]
+    InvalidStateTransition {
+        /// Current state of the subscription.
+        current_state: String,
+        /// Action that was attempted.
+        action: String,
+    },
+
+    /// Usage reporting error.
+    ///
+    /// This error occurs when reporting usage for a usage-based subscription fails.
+    #[error("Usage reporting error: {0}")]
+    UsageError(String),
+
+    /// Proration calculation error.
+    ///
+    /// This error occurs when calculating proration for mid-cycle changes fails.
+    #[error("Proration error: {0}")]
+    ProrationError(String),
+
+    /// Payment method change error.
+    ///
+    /// This error occurs when updating a subscription's payment method fails.
+    #[error("Payment method change error: {0}")]
+    PaymentMethodChangeError(String),
+
+    /// Subscription not found.
+    ///
+    /// This error occurs when a subscription with the given ID does not exist.
+    #[error("Subscription not found: {0}")]
+    SubscriptionNotFound(String),
+
+    /// Plan not found.
+    ///
+    /// This error occurs when a subscription plan with the given ID does not exist.
+    #[error("Plan not found: {0}")]
+    PlanNotFound(String),
 }
 
 #[cfg(test)]

--- a/tap-mcp-bridge/src/mcp/mod.rs
+++ b/tap-mcp-bridge/src/mcp/mod.rs
@@ -80,6 +80,7 @@ pub mod models;
 pub mod orders;
 pub mod payment;
 pub mod products;
+pub mod subscriptions;
 pub mod tools;
 
 pub use tools::{

--- a/tap-mcp-bridge/src/mcp/subscriptions/lifecycle.rs
+++ b/tap-mcp-bridge/src/mcp/subscriptions/lifecycle.rs
@@ -1,0 +1,969 @@
+//! Subscription lifecycle management using typestate pattern.
+//!
+//! Makes invalid state transitions compile-time errors.
+
+use std::marker::PhantomData;
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+use super::models::{BillingCycle, PlanId, SubscriptionId};
+use crate::mcp::models::Address;
+
+// ============================================================================
+// State Marker Types (Zero-Sized)
+// ============================================================================
+
+/// Trial state - subscription is in trial period.
+#[derive(Debug, Clone, Copy)]
+pub struct Trial;
+
+/// Active state - subscription is paid and active.
+#[derive(Debug, Clone, Copy)]
+pub struct Active;
+
+/// Paused state - subscription billing is suspended.
+#[derive(Debug, Clone, Copy)]
+pub struct Paused;
+
+/// `PastDue` state - payment failed, in grace period.
+#[derive(Debug, Clone, Copy)]
+pub struct PastDue;
+
+/// Canceled state - subscription terminated.
+#[derive(Debug, Clone, Copy)]
+pub struct Canceled;
+
+/// Expired state - subscription validity period ended.
+#[derive(Debug, Clone, Copy)]
+pub struct Expired;
+
+// ============================================================================
+// Subscription with Typestate
+// ============================================================================
+
+/// Subscription instance with compile-time state tracking.
+///
+/// Uses typestate pattern to ensure only valid state transitions compile.
+/// For example, you cannot call `cancel()` on an already `Canceled` subscription.
+///
+/// # State Machine
+///
+/// ```text
+/// Trial ──────┬─► Active ◄─────┬─► Paused ──► Active
+///             │      │         │
+///             │      ▼         │
+///             │   PastDue ─────┤
+///             │      │         │
+///             ▼      ▼         ▼
+///          Canceled/Expired
+/// ```
+#[derive(Debug, Clone)]
+pub struct Subscription<State> {
+    /// Core subscription data (state-independent).
+    pub(crate) data: SubscriptionData,
+    /// Phantom marker for state.
+    _state: PhantomData<State>,
+}
+
+/// State-independent subscription data.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionData {
+    /// Unique subscription identifier.
+    pub id: SubscriptionId,
+    /// Associated plan identifier.
+    pub plan_id: PlanId,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Current quantity (seats, licenses).
+    pub quantity: u32,
+    /// Creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Current period start.
+    pub current_period_start: DateTime<Utc>,
+    /// Current period end.
+    pub current_period_end: DateTime<Utc>,
+    /// Billing address.
+    pub billing_address: Option<Address>,
+    /// Billing cycle.
+    pub billing_cycle: BillingCycle,
+    /// Currency code (ISO 4217).
+    pub currency: String,
+    /// Current period amount.
+    pub current_period_amount: Decimal,
+    /// Payment method reference (encrypted in APC).
+    pub payment_method_id: Option<String>,
+    /// Merchant-specific metadata.
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+    /// State-specific data.
+    pub state_data: StateData,
+}
+
+/// State-specific data stored alongside subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum StateData {
+    /// Trial state data.
+    Trial {
+        /// Trial start timestamp.
+        trial_start: DateTime<Utc>,
+        /// Trial end timestamp.
+        trial_end: DateTime<Utc>,
+    },
+    /// Active state data.
+    Active {
+        /// Activation timestamp.
+        activated_at: DateTime<Utc>,
+        /// Last successful payment timestamp.
+        last_payment_at: Option<DateTime<Utc>>,
+    },
+    /// Paused state data.
+    Paused {
+        /// Pause timestamp.
+        paused_at: DateTime<Utc>,
+        /// Scheduled resume timestamp (optional).
+        resume_at: Option<DateTime<Utc>>,
+        /// Pause reason.
+        pause_reason: Option<String>,
+    },
+    /// Past-due state data.
+    PastDue {
+        /// When subscription became past-due.
+        became_past_due_at: DateTime<Utc>,
+        /// Grace period expiration.
+        grace_period_ends: DateTime<Utc>,
+        /// Number of payment failure attempts.
+        failure_count: u32,
+        /// Last failure reason.
+        last_failure_reason: Option<String>,
+    },
+    /// Canceled state data.
+    Canceled {
+        /// Cancellation timestamp.
+        canceled_at: DateTime<Utc>,
+        /// Effective end date.
+        effective_end: DateTime<Utc>,
+        /// Cancellation reason.
+        cancellation_reason: Option<String>,
+        /// Refund amount.
+        refund_amount: Option<Decimal>,
+    },
+    /// Expired state data.
+    Expired {
+        /// Expiration timestamp.
+        expired_at: DateTime<Utc>,
+    },
+}
+
+// ============================================================================
+// State-Specific Implementations
+// ============================================================================
+
+// --- Trial State Methods ---
+
+impl Subscription<Trial> {
+    /// Activates trial subscription to active paid state.
+    ///
+    /// Called when trial converts to paid subscription.
+    #[must_use]
+    pub fn activate(self) -> Subscription<Active> {
+        let mut data = self.data;
+        data.state_data = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Cancels trial without converting to paid.
+    #[must_use]
+    pub fn cancel(self, reason: Option<String>) -> Subscription<Canceled> {
+        let now = Utc::now();
+        let mut data = self.data;
+        data.state_data = StateData::Canceled {
+            canceled_at: now,
+            effective_end: now,
+            cancellation_reason: reason,
+            refund_amount: None,
+        };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Returns trial end date.
+    #[must_use]
+    pub fn trial_ends_at(&self) -> Option<DateTime<Utc>> {
+        match &self.data.state_data {
+            StateData::Trial { trial_end, .. } => Some(*trial_end),
+            _ => None,
+        }
+    }
+
+    /// Checks if trial has expired.
+    #[must_use]
+    pub fn is_trial_expired(&self) -> bool {
+        self.trial_ends_at().is_some_and(|end| end < Utc::now())
+    }
+}
+
+// --- Active State Methods ---
+
+impl Subscription<Active> {
+    /// Pauses active subscription.
+    ///
+    /// Billing is suspended until resumed.
+    #[must_use]
+    pub fn pause(
+        self,
+        reason: Option<String>,
+        resume_at: Option<DateTime<Utc>>,
+    ) -> Subscription<Paused> {
+        let mut data = self.data;
+        data.state_data =
+            StateData::Paused { paused_at: Utc::now(), resume_at, pause_reason: reason };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Cancels active subscription.
+    ///
+    /// # Arguments
+    ///
+    /// * `reason` - Cancellation reason for records
+    /// * `immediate` - If true, cancel immediately; if false, cancel at period end
+    /// * `refund_amount` - Optional prorated refund amount
+    ///
+    /// # Errors
+    ///
+    /// Returns error if `refund_amount` is negative.
+    pub fn cancel(
+        self,
+        reason: Option<String>,
+        immediate: bool,
+        refund_amount: Option<Decimal>,
+    ) -> crate::error::Result<Subscription<Canceled>> {
+        // Validate refund amount is non-negative
+        if let Some(ref amount) = refund_amount
+            && amount.is_sign_negative()
+        {
+            return Err(crate::error::BridgeError::SubscriptionError(
+                "Refund amount cannot be negative".into(),
+            ));
+        }
+
+        let now = Utc::now();
+        let effective_end = if immediate {
+            now
+        } else {
+            self.data.current_period_end
+        };
+
+        let mut data = self.data;
+        data.state_data = StateData::Canceled {
+            canceled_at: now,
+            effective_end,
+            cancellation_reason: reason,
+            refund_amount,
+        };
+        Ok(Subscription { data, _state: PhantomData })
+    }
+
+    /// Transitions to past-due when payment fails.
+    #[must_use]
+    pub fn mark_past_due(
+        self,
+        grace_period_days: u32,
+        failure_reason: Option<String>,
+    ) -> Subscription<PastDue> {
+        let now = Utc::now();
+        let mut data = self.data;
+        data.state_data = StateData::PastDue {
+            became_past_due_at: now,
+            grace_period_ends: now + chrono::Duration::days(i64::from(grace_period_days)),
+            failure_count: 1,
+            last_failure_reason: failure_reason,
+        };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Updates quantity (seats/licenses) with proration.
+    #[must_use]
+    pub fn update_quantity(mut self, new_quantity: u32) -> Self {
+        self.data.quantity = new_quantity;
+        self
+    }
+}
+
+// --- Paused State Methods ---
+
+impl Subscription<Paused> {
+    /// Resumes paused subscription.
+    #[must_use]
+    pub fn resume(self) -> Subscription<Active> {
+        let mut data = self.data;
+        data.state_data = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Cancels paused subscription.
+    #[must_use]
+    pub fn cancel(self, reason: Option<String>) -> Subscription<Canceled> {
+        let now = Utc::now();
+        let mut data = self.data;
+        data.state_data = StateData::Canceled {
+            canceled_at: now,
+            effective_end: now,
+            cancellation_reason: reason,
+            refund_amount: None,
+        };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Returns scheduled resume date if set.
+    #[must_use]
+    pub fn resume_at(&self) -> Option<DateTime<Utc>> {
+        match &self.data.state_data {
+            StateData::Paused { resume_at, .. } => *resume_at,
+            _ => None,
+        }
+    }
+}
+
+// --- PastDue State Methods ---
+
+impl Subscription<PastDue> {
+    /// Recovers to active when payment succeeds.
+    #[must_use]
+    pub fn recover(self) -> Subscription<Active> {
+        let mut data = self.data;
+        data.state_data =
+            StateData::Active { activated_at: Utc::now(), last_payment_at: Some(Utc::now()) };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Cancels after grace period exhausted.
+    #[must_use]
+    pub fn expire_grace_period(self) -> Subscription<Canceled> {
+        let now = Utc::now();
+        let mut data = self.data;
+        data.state_data = StateData::Canceled {
+            canceled_at: now,
+            effective_end: now,
+            cancellation_reason: Some("Payment failed - grace period expired".into()),
+            refund_amount: None,
+        };
+        Subscription { data, _state: PhantomData }
+    }
+
+    /// Increments failure count on retry failure.
+    #[must_use]
+    pub fn record_failure(mut self, reason: Option<String>) -> Self {
+        if let StateData::PastDue { failure_count, last_failure_reason, .. } =
+            &mut self.data.state_data
+        {
+            *failure_count += 1;
+            *last_failure_reason = reason;
+        }
+        self
+    }
+
+    /// Returns failure count.
+    #[must_use]
+    pub fn failure_count(&self) -> u32 {
+        match &self.data.state_data {
+            StateData::PastDue { failure_count, .. } => *failure_count,
+            _ => 0,
+        }
+    }
+}
+
+// --- Common Methods (All States) ---
+
+impl<S> Subscription<S> {
+    /// Returns the subscription ID.
+    #[must_use]
+    pub fn id(&self) -> &SubscriptionId {
+        &self.data.id
+    }
+
+    /// Returns the plan ID.
+    #[must_use]
+    pub fn plan_id(&self) -> &PlanId {
+        &self.data.plan_id
+    }
+
+    /// Returns the consumer ID.
+    #[must_use]
+    pub fn consumer_id(&self) -> &str {
+        &self.data.consumer_id
+    }
+
+    /// Returns current quantity.
+    #[must_use]
+    pub fn quantity(&self) -> u32 {
+        self.data.quantity
+    }
+
+    /// Returns current period end date.
+    #[must_use]
+    pub fn current_period_end(&self) -> DateTime<Utc> {
+        self.data.current_period_end
+    }
+
+    /// Returns the underlying data (for serialization).
+    #[must_use]
+    pub fn into_data(self) -> SubscriptionData {
+        self.data
+    }
+
+    /// Returns reference to underlying data.
+    #[must_use]
+    pub fn data(&self) -> &SubscriptionData {
+        &self.data
+    }
+}
+
+// ============================================================================
+// Runtime State (for API responses)
+// ============================================================================
+
+/// Runtime subscription status for API responses.
+///
+/// Unlike the typestate `Subscription<S>`, this is used for serialization
+/// and when the state must be determined at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionStatus {
+    /// Trial state.
+    Trial,
+    /// Active state.
+    Active,
+    /// Paused state.
+    Paused,
+    /// Past-due state.
+    PastDue,
+    /// Canceled state.
+    Canceled,
+    /// Expired state.
+    Expired,
+}
+
+/// Dynamic subscription representation for API responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionResponse {
+    /// Subscription data.
+    #[serde(flatten)]
+    pub data: SubscriptionData,
+    /// Current status.
+    pub status: SubscriptionStatus,
+}
+
+impl SubscriptionResponse {
+    /// Creates response from typed subscription.
+    #[must_use]
+    pub fn from_trial(sub: Subscription<Trial>) -> Self {
+        Self { data: sub.data, status: SubscriptionStatus::Trial }
+    }
+
+    /// Creates response from active subscription.
+    #[must_use]
+    pub fn from_active(sub: Subscription<Active>) -> Self {
+        Self { data: sub.data, status: SubscriptionStatus::Active }
+    }
+
+    /// Creates response from paused subscription.
+    #[must_use]
+    pub fn from_paused(sub: Subscription<Paused>) -> Self {
+        Self { data: sub.data, status: SubscriptionStatus::Paused }
+    }
+
+    /// Creates response from past-due subscription.
+    #[must_use]
+    pub fn from_past_due(sub: Subscription<PastDue>) -> Self {
+        Self { data: sub.data, status: SubscriptionStatus::PastDue }
+    }
+
+    /// Creates response from canceled subscription.
+    #[must_use]
+    pub fn from_canceled(sub: Subscription<Canceled>) -> Self {
+        Self { data: sub.data, status: SubscriptionStatus::Canceled }
+    }
+
+    /// Creates response from expired subscription.
+    #[must_use]
+    pub fn from_expired(sub: Subscription<Expired>) -> Self {
+        Self { data: sub.data, status: SubscriptionStatus::Expired }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unreachable,
+    reason = "Test code uses unreachable! for invalid state assertions"
+)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // Test Helpers
+    // ========================================================================
+
+    fn create_test_subscription_data() -> SubscriptionData {
+        let now = Utc::now();
+        SubscriptionData {
+            id: SubscriptionId::new("sub-test-123").unwrap(),
+            plan_id: PlanId::new("plan-basic").unwrap(),
+            consumer_id: "consumer-456".to_owned(),
+            quantity: 1,
+            created_at: now,
+            current_period_start: now,
+            current_period_end: now + chrono::Duration::days(30),
+            billing_address: None,
+            billing_cycle: BillingCycle::Monthly { anchor_day: 1 },
+            currency: "USD".to_owned(),
+            current_period_amount: Decimal::new(999, 2),
+            payment_method_id: None,
+            metadata: serde_json::Value::Null,
+            state_data: StateData::Trial {
+                trial_start: now,
+                trial_end: now + chrono::Duration::days(14),
+            },
+        }
+    }
+
+    // ========================================================================
+    // Trial State Tests
+    // ========================================================================
+
+    #[test]
+    fn test_trial_to_active_transition() {
+        let data = create_test_subscription_data();
+        let trial_sub = Subscription::<Trial> { data, _state: PhantomData };
+
+        let active_sub = trial_sub.activate();
+
+        match active_sub.data.state_data {
+            StateData::Active { activated_at, last_payment_at } => {
+                assert!(activated_at <= Utc::now());
+                assert!(last_payment_at.is_none());
+            }
+            _ => unreachable!("Expected Active state"),
+        }
+    }
+
+    #[test]
+    fn test_trial_to_canceled_transition() {
+        let data = create_test_subscription_data();
+        let trial_sub = Subscription::<Trial> { data, _state: PhantomData };
+
+        let canceled_sub = trial_sub.cancel(Some("User requested".to_owned()));
+
+        match canceled_sub.data.state_data {
+            StateData::Canceled {
+                canceled_at,
+                effective_end,
+                cancellation_reason,
+                refund_amount,
+            } => {
+                assert!(canceled_at <= Utc::now());
+                assert_eq!(canceled_at, effective_end);
+                assert_eq!(cancellation_reason.as_deref(), Some("User requested"));
+                assert!(refund_amount.is_none());
+            }
+            _ => unreachable!("Expected Canceled state"),
+        }
+    }
+
+    #[test]
+    fn test_trial_ends_at() {
+        let data = create_test_subscription_data();
+        let trial_sub = Subscription::<Trial> { data, _state: PhantomData };
+
+        let trial_end = trial_sub.trial_ends_at();
+        assert!(trial_end.is_some());
+    }
+
+    #[test]
+    fn test_trial_is_expired() {
+        let now = Utc::now();
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Trial {
+            trial_start: now - chrono::Duration::days(20),
+            trial_end: now - chrono::Duration::days(5),
+        };
+        let trial_sub = Subscription::<Trial> { data, _state: PhantomData };
+
+        assert!(trial_sub.is_trial_expired());
+    }
+
+    #[test]
+    fn test_trial_not_expired() {
+        let now = Utc::now();
+        let mut data = create_test_subscription_data();
+        data.state_data =
+            StateData::Trial { trial_start: now, trial_end: now + chrono::Duration::days(14) };
+        let trial_sub = Subscription::<Trial> { data, _state: PhantomData };
+
+        assert!(!trial_sub.is_trial_expired());
+    }
+
+    // ========================================================================
+    // Active State Tests
+    // ========================================================================
+
+    #[test]
+    fn test_active_to_paused_transition() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        let active_sub = Subscription::<Active> { data, _state: PhantomData };
+
+        let resume_at = Utc::now() + chrono::Duration::days(30);
+        let paused_sub = active_sub.pause(Some("Vacation".to_owned()), Some(resume_at));
+
+        match paused_sub.data.state_data {
+            StateData::Paused { paused_at, resume_at: r, pause_reason } => {
+                assert!(paused_at <= Utc::now());
+                assert_eq!(r, Some(resume_at));
+                assert_eq!(pause_reason.as_deref(), Some("Vacation"));
+            }
+            _ => unreachable!("Expected Paused state"),
+        }
+    }
+
+    #[test]
+    fn test_active_to_canceled_immediate() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        let active_sub = Subscription::<Active> { data, _state: PhantomData };
+
+        let refund = Decimal::new(500, 2);
+        let canceled_sub =
+            active_sub.cancel(Some("Not satisfied".to_owned()), true, Some(refund)).unwrap();
+
+        match canceled_sub.data.state_data {
+            StateData::Canceled { canceled_at, effective_end, refund_amount, .. } => {
+                assert_eq!(canceled_at, effective_end);
+                assert_eq!(refund_amount, Some(refund));
+            }
+            _ => unreachable!("Expected Canceled state"),
+        }
+    }
+
+    #[test]
+    fn test_active_to_canceled_at_period_end() {
+        let mut data = create_test_subscription_data();
+        let period_end = data.current_period_end;
+        data.state_data = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        let active_sub = Subscription::<Active> { data, _state: PhantomData };
+
+        let canceled_sub =
+            active_sub.cancel(Some("Switching provider".to_owned()), false, None).unwrap();
+
+        match canceled_sub.data.state_data {
+            StateData::Canceled { canceled_at, effective_end, .. } => {
+                assert!(canceled_at < effective_end);
+                assert_eq!(effective_end, period_end);
+            }
+            _ => unreachable!("Expected Canceled state"),
+        }
+    }
+
+    #[test]
+    fn test_active_to_past_due_transition() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Active {
+            activated_at: Utc::now(),
+            last_payment_at: Some(Utc::now() - chrono::Duration::days(30)),
+        };
+        let active_sub = Subscription::<Active> { data, _state: PhantomData };
+
+        let grace_period = 7;
+        let past_due_sub =
+            active_sub.mark_past_due(grace_period, Some("Insufficient funds".to_owned()));
+
+        match past_due_sub.data.state_data {
+            StateData::PastDue {
+                became_past_due_at,
+                grace_period_ends,
+                failure_count,
+                last_failure_reason,
+            } => {
+                assert!(became_past_due_at <= Utc::now());
+                assert!(grace_period_ends > became_past_due_at);
+                assert_eq!(failure_count, 1);
+                assert_eq!(last_failure_reason.as_deref(), Some("Insufficient funds"));
+            }
+            _ => unreachable!("Expected PastDue state"),
+        }
+    }
+
+    #[test]
+    fn test_active_update_quantity() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        let active_sub = Subscription::<Active> { data, _state: PhantomData };
+
+        let updated_sub = active_sub.update_quantity(5);
+        assert_eq!(updated_sub.quantity(), 5);
+    }
+
+    // ========================================================================
+    // Paused State Tests
+    // ========================================================================
+
+    #[test]
+    fn test_paused_to_active_transition() {
+        let mut data = create_test_subscription_data();
+        data.state_data =
+            StateData::Paused { paused_at: Utc::now(), resume_at: None, pause_reason: None };
+        let paused_sub = Subscription::<Paused> { data, _state: PhantomData };
+
+        let active_sub = paused_sub.resume();
+
+        match active_sub.data.state_data {
+            StateData::Active { activated_at, .. } => {
+                assert!(activated_at <= Utc::now());
+            }
+            _ => unreachable!("Expected Active state"),
+        }
+    }
+
+    #[test]
+    fn test_paused_to_canceled_transition() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Paused {
+            paused_at: Utc::now(),
+            resume_at: None,
+            pause_reason: Some("Testing".to_owned()),
+        };
+        let paused_sub = Subscription::<Paused> { data, _state: PhantomData };
+
+        let canceled_sub = paused_sub.cancel(Some("No longer needed".to_owned()));
+
+        match canceled_sub.data.state_data {
+            StateData::Canceled { cancellation_reason, .. } => {
+                assert_eq!(cancellation_reason.as_deref(), Some("No longer needed"));
+            }
+            _ => unreachable!("Expected Canceled state"),
+        }
+    }
+
+    #[test]
+    fn test_paused_resume_at() {
+        let resume_time = Utc::now() + chrono::Duration::days(15);
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Paused {
+            paused_at: Utc::now(),
+            resume_at: Some(resume_time),
+            pause_reason: None,
+        };
+        let paused_sub = Subscription::<Paused> { data, _state: PhantomData };
+
+        assert_eq!(paused_sub.resume_at(), Some(resume_time));
+    }
+
+    // ========================================================================
+    // PastDue State Tests
+    // ========================================================================
+
+    #[test]
+    fn test_past_due_to_active_recovery() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::PastDue {
+            became_past_due_at: Utc::now() - chrono::Duration::days(3),
+            grace_period_ends: Utc::now() + chrono::Duration::days(4),
+            failure_count: 2,
+            last_failure_reason: Some("Card declined".to_owned()),
+        };
+        let past_due_sub = Subscription::<PastDue> { data, _state: PhantomData };
+
+        let active_sub = past_due_sub.recover();
+
+        match active_sub.data.state_data {
+            StateData::Active { activated_at, last_payment_at } => {
+                assert!(activated_at <= Utc::now());
+                assert!(last_payment_at.is_some());
+            }
+            _ => unreachable!("Expected Active state"),
+        }
+    }
+
+    #[test]
+    fn test_past_due_grace_period_expiration() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::PastDue {
+            became_past_due_at: Utc::now() - chrono::Duration::days(10),
+            grace_period_ends: Utc::now() - chrono::Duration::days(1),
+            failure_count: 5,
+            last_failure_reason: Some("Card expired".to_owned()),
+        };
+        let past_due_sub = Subscription::<PastDue> { data, _state: PhantomData };
+
+        let canceled_sub = past_due_sub.expire_grace_period();
+
+        match canceled_sub.data.state_data {
+            StateData::Canceled { cancellation_reason, .. } => {
+                assert!(cancellation_reason.unwrap().contains("grace period expired"));
+            }
+            _ => unreachable!("Expected Canceled state"),
+        }
+    }
+
+    #[test]
+    fn test_past_due_record_failure() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::PastDue {
+            became_past_due_at: Utc::now(),
+            grace_period_ends: Utc::now() + chrono::Duration::days(7),
+            failure_count: 1,
+            last_failure_reason: Some("First failure".to_owned()),
+        };
+        let past_due_sub = Subscription::<PastDue> { data, _state: PhantomData };
+
+        let updated_sub = past_due_sub.record_failure(Some("Second failure".to_owned()));
+
+        assert_eq!(updated_sub.failure_count(), 2);
+        match updated_sub.data.state_data {
+            StateData::PastDue { last_failure_reason, .. } => {
+                assert_eq!(last_failure_reason.as_deref(), Some("Second failure"));
+            }
+            _ => unreachable!("Expected PastDue state"),
+        }
+    }
+
+    #[test]
+    fn test_past_due_failure_count() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::PastDue {
+            became_past_due_at: Utc::now(),
+            grace_period_ends: Utc::now() + chrono::Duration::days(7),
+            failure_count: 3,
+            last_failure_reason: None,
+        };
+        let past_due_sub = Subscription::<PastDue> { data, _state: PhantomData };
+
+        assert_eq!(past_due_sub.failure_count(), 3);
+    }
+
+    // ========================================================================
+    // SubscriptionStatus Serialization Tests
+    // ========================================================================
+
+    #[test]
+    fn test_subscription_status_trial_serialization() {
+        let status = SubscriptionStatus::Trial;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"trial\"");
+    }
+
+    #[test]
+    fn test_subscription_status_active_serialization() {
+        let status = SubscriptionStatus::Active;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"active\"");
+    }
+
+    #[test]
+    fn test_subscription_status_paused_serialization() {
+        let status = SubscriptionStatus::Paused;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"paused\"");
+    }
+
+    #[test]
+    fn test_subscription_status_past_due_serialization() {
+        let status = SubscriptionStatus::PastDue;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"past_due\"");
+    }
+
+    #[test]
+    fn test_subscription_status_canceled_serialization() {
+        let status = SubscriptionStatus::Canceled;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"canceled\"");
+    }
+
+    #[test]
+    fn test_subscription_status_expired_serialization() {
+        let status = SubscriptionStatus::Expired;
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(json, "\"expired\"");
+    }
+
+    // ========================================================================
+    // StateData Serialization Tests
+    // ========================================================================
+
+    #[test]
+    fn test_state_data_trial_serialization() {
+        let now = Utc::now();
+        let state =
+            StateData::Trial { trial_start: now, trial_end: now + chrono::Duration::days(14) };
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(json.contains("\"state\":\"trial\""));
+    }
+
+    #[test]
+    fn test_state_data_active_serialization() {
+        let state = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(json.contains("\"state\":\"active\""));
+    }
+
+    #[test]
+    fn test_state_data_paused_serialization() {
+        let state = StateData::Paused {
+            paused_at: Utc::now(),
+            resume_at: None,
+            pause_reason: Some("Testing".to_owned()),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(json.contains("\"state\":\"paused\""));
+    }
+
+    #[test]
+    fn test_state_data_canceled_serialization() {
+        let state = StateData::Canceled {
+            canceled_at: Utc::now(),
+            effective_end: Utc::now(),
+            cancellation_reason: Some("Test".to_owned()),
+            refund_amount: Some(Decimal::new(1000, 2)),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(json.contains("\"state\":\"canceled\""));
+    }
+
+    // ========================================================================
+    // SubscriptionResponse Tests
+    // ========================================================================
+
+    #[test]
+    fn test_subscription_response_from_trial() {
+        let data = create_test_subscription_data();
+        let trial_sub = Subscription::<Trial> { data, _state: PhantomData };
+        let response = SubscriptionResponse::from_trial(trial_sub);
+
+        assert_eq!(response.status, SubscriptionStatus::Trial);
+    }
+
+    #[test]
+    fn test_subscription_response_from_active() {
+        let mut data = create_test_subscription_data();
+        data.state_data = StateData::Active { activated_at: Utc::now(), last_payment_at: None };
+        let active_sub = Subscription::<Active> { data, _state: PhantomData };
+        let response = SubscriptionResponse::from_active(active_sub);
+
+        assert_eq!(response.status, SubscriptionStatus::Active);
+    }
+
+    #[test]
+    fn test_subscription_response_roundtrip() {
+        let data = create_test_subscription_data();
+        let trial_sub = Subscription::<Trial> { data, _state: PhantomData };
+        let response = SubscriptionResponse::from_trial(trial_sub);
+
+        let json = serde_json::to_string(&response).unwrap();
+        let parsed: SubscriptionResponse = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.status, SubscriptionStatus::Trial);
+        assert_eq!(parsed.data.id, response.data.id);
+    }
+}

--- a/tap-mcp-bridge/src/mcp/subscriptions/mod.rs
+++ b/tap-mcp-bridge/src/mcp/subscriptions/mod.rs
@@ -1,0 +1,34 @@
+//! Subscription management for TAP-MCP bridge.
+//!
+//! This module provides comprehensive subscription functionality including
+//! plan management, subscription lifecycle, usage tracking, and proration.
+
+pub mod lifecycle;
+pub mod models;
+pub mod pricing;
+pub mod proration;
+pub mod tools;
+
+pub use lifecycle::{
+    Active, Canceled, Expired, PastDue, Paused, StateData, Subscription, SubscriptionData,
+    SubscriptionResponse, SubscriptionStatus, Trial,
+};
+pub use models::{
+    BillingCycle, MetricUsage, PlanCatalog, PlanFeature, PlanId, SubscriptionId, SubscriptionPlan,
+    TrialConfig, UsageAction, UsageRecord, UsageSummary,
+};
+pub use pricing::{
+    FlatRatePrice, HybridPrice, IncludedUsage, OveragePricing, PerSeatPrice, PriceTier,
+    PricingModel, TierMode, TieredPrice, UsageAggregation, UsageBasedPrice, UsageMetric, UsageTier,
+    VolumeDiscount,
+};
+pub use proration::{calculate_charge, calculate_credit, calculate_next_billing_date};
+pub use tools::{
+    CancelSubscriptionParams, CreateSubscriptionParams, GetPlanParams, GetPlansParams,
+    GetSubscriptionParams, GetUsageParams, PauseSubscriptionParams, PreviewProrationParams,
+    ProrationBehavior, ProrationLineItem, ProrationPreview, ReportUsageParams,
+    ResumeSubscriptionParams, UpdatePaymentMethodParams, UpdateSubscriptionParams,
+    cancel_subscription, create_subscription, get_subscription, get_subscription_plan,
+    get_subscription_plans, get_usage, pause_subscription, preview_proration, report_usage,
+    resume_subscription, update_payment_method, update_subscription,
+};

--- a/tap-mcp-bridge/src/mcp/subscriptions/models.rs
+++ b/tap-mcp-bridge/src/mcp/subscriptions/models.rs
@@ -1,0 +1,510 @@
+//! Subscription data models for TAP-MCP bridge.
+//!
+//! This module defines the data structures for subscription management
+//! including plans, subscriptions, and billing cycles.
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{BridgeError, Result};
+
+/// Maximum allowed usage quantity to prevent overflow and abuse.
+/// Set to 1 trillion units (10^12).
+const MAX_USAGE_QUANTITY: u64 = 1_000_000_000_000;
+
+/// Unique identifier for a subscription plan.
+///
+/// Wraps merchant-provided plan ID with type safety.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct PlanId(String);
+
+impl PlanId {
+    /// Creates a new plan ID after validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if ID is empty, exceeds 64 characters, or contains invalid characters.
+    /// Only alphanumeric characters, hyphens, and underscores are allowed.
+    pub fn new<S: Into<String>>(id: S) -> Result<Self> {
+        let id = id.into();
+        if id.is_empty() {
+            return Err(BridgeError::InvalidPlanId("plan_id cannot be empty".into()));
+        }
+        if id.len() > 64 {
+            return Err(BridgeError::InvalidPlanId("plan_id must be 64 characters or less".into()));
+        }
+        if !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+            return Err(BridgeError::InvalidPlanId(
+                "plan_id can only contain alphanumeric characters, hyphens, and underscores".into(),
+            ));
+        }
+        Ok(Self(id))
+    }
+
+    /// Returns the inner string reference.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Unique identifier for a subscription instance.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SubscriptionId(String);
+
+impl SubscriptionId {
+    /// Creates a new subscription ID after validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if ID is empty, exceeds 64 characters, or contains invalid characters.
+    /// Only alphanumeric characters, hyphens, and underscores are allowed.
+    pub fn new<S: Into<String>>(id: S) -> Result<Self> {
+        let id = id.into();
+        if id.is_empty() {
+            return Err(BridgeError::InvalidSubscriptionId(
+                "subscription_id cannot be empty".into(),
+            ));
+        }
+        if id.len() > 64 {
+            return Err(BridgeError::InvalidSubscriptionId(
+                "subscription_id must be 64 characters or less".into(),
+            ));
+        }
+        if !id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+            return Err(BridgeError::InvalidSubscriptionId(
+                "subscription_id can only contain alphanumeric characters, hyphens, and \
+                 underscores"
+                    .into(),
+            ));
+        }
+        Ok(Self(id))
+    }
+
+    /// Returns the inner string reference.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Subscription plan defining pricing and terms.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionPlan {
+    /// Unique plan identifier.
+    pub id: PlanId,
+    /// Display name.
+    pub name: String,
+    /// Plan description.
+    pub description: String,
+    /// Pricing model for this plan.
+    pub pricing: crate::mcp::subscriptions::pricing::PricingModel,
+    /// Billing cycle configuration.
+    pub billing_cycle: BillingCycle,
+    /// Trial configuration (optional).
+    pub trial: Option<TrialConfig>,
+    /// Features included in this plan.
+    pub features: Vec<PlanFeature>,
+    /// Whether plan is currently available for new subscriptions.
+    pub active: bool,
+    /// Currency code (ISO 4217).
+    pub currency: String,
+    /// Metadata for merchant-specific extensions.
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+/// Feature included in a subscription plan.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanFeature {
+    /// Feature identifier.
+    pub id: String,
+    /// Display name.
+    pub name: String,
+    /// Feature description.
+    pub description: Option<String>,
+    /// Included quantity (None = unlimited).
+    pub included_quantity: Option<u64>,
+    /// Unit for quantity measurement.
+    pub unit: Option<String>,
+}
+
+/// Trial period configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrialConfig {
+    /// Duration of trial in days.
+    pub duration_days: u32,
+    /// Whether payment method required at trial start.
+    pub requires_payment_method: bool,
+    /// Whether trial auto-converts to paid subscription.
+    pub auto_convert: bool,
+}
+
+/// Billing cycle configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BillingCycle {
+    /// Monthly billing (day of month).
+    Monthly {
+        /// Day of month for billing (1-28 recommended).
+        anchor_day: u8,
+    },
+    /// Annual billing.
+    Annual {
+        /// Month for billing anniversary (1-12).
+        anchor_month: u8,
+        /// Day of month for billing anniversary (1-28 recommended).
+        anchor_day: u8,
+    },
+    /// Weekly billing.
+    Weekly {
+        /// Day of week (0 = Sunday, 6 = Saturday).
+        anchor_day: u8,
+    },
+    /// Custom interval in days.
+    Custom {
+        /// Number of days between billing cycles.
+        interval_days: u32,
+    },
+    /// One-time charge with optional validity period.
+    OneTime {
+        /// Validity period in days (None = perpetual).
+        validity_days: Option<u32>,
+    },
+}
+
+impl BillingCycle {
+    /// Returns human-readable interval description.
+    #[must_use]
+    pub fn interval_display(&self) -> &'static str {
+        match self {
+            Self::Monthly { .. } => "month",
+            Self::Annual { .. } => "year",
+            Self::Weekly { .. } => "week",
+            Self::Custom { interval_days } if *interval_days == 1 => "day",
+            Self::Custom { .. } => "custom period",
+            Self::OneTime { .. } => "one-time",
+        }
+    }
+}
+
+/// Subscription plan catalog with pagination.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlanCatalog {
+    /// Plans in current page.
+    pub plans: Vec<SubscriptionPlan>,
+    /// Total plan count.
+    pub total: u32,
+    /// Current page number.
+    pub page: u32,
+    /// Items per page.
+    pub per_page: u32,
+}
+
+/// Usage record for usage-based billing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageRecord {
+    /// Subscription ID.
+    pub subscription_id: SubscriptionId,
+    /// Metric identifier.
+    pub metric_id: String,
+    /// Usage quantity.
+    pub quantity: u64,
+    /// Timestamp of usage (defaults to now).
+    pub timestamp: DateTime<Utc>,
+    /// Idempotency key to prevent duplicate reporting.
+    pub idempotency_key: Option<String>,
+    /// Action: set absolute value or increment.
+    pub action: UsageAction,
+}
+
+impl UsageRecord {
+    /// Validates the usage record.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - quantity exceeds maximum allowed value
+    /// - timestamp is in the future
+    /// - timestamp is more than 24 hours in the past
+    pub fn validate(&self) -> Result<()> {
+        // Validate quantity
+        if self.quantity > MAX_USAGE_QUANTITY {
+            return Err(BridgeError::UsageError(format!(
+                "Usage quantity {} exceeds maximum allowed value of {MAX_USAGE_QUANTITY}",
+                self.quantity
+            )));
+        }
+
+        // Validate timestamp is not in the future
+        let now = Utc::now();
+        if self.timestamp > now {
+            return Err(BridgeError::UsageError("Usage timestamp cannot be in the future".into()));
+        }
+
+        // Validate timestamp is not too far in the past (24 hours)
+        let twenty_four_hours_ago = now - chrono::Duration::hours(24);
+        if self.timestamp < twenty_four_hours_ago {
+            return Err(BridgeError::UsageError(
+                "Usage timestamp cannot be more than 24 hours in the past".into(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Usage reporting action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageAction {
+    /// Set absolute value (replaces current).
+    Set,
+    /// Increment current value.
+    Increment,
+}
+
+/// Current usage summary for a subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageSummary {
+    /// Subscription ID.
+    pub subscription_id: SubscriptionId,
+    /// Billing period start.
+    pub period_start: DateTime<Utc>,
+    /// Billing period end.
+    pub period_end: DateTime<Utc>,
+    /// Usage by metric.
+    pub metrics: Vec<MetricUsage>,
+    /// Estimated charges for current usage.
+    pub estimated_charges: Decimal,
+    /// Currency code.
+    pub currency: String,
+}
+
+/// Usage for a single metric.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetricUsage {
+    /// Metric identifier.
+    pub metric_id: String,
+    /// Metric display name.
+    pub metric_name: String,
+    /// Current usage quantity.
+    pub current_usage: u64,
+    /// Included quantity (from plan).
+    pub included: Option<u64>,
+    /// Overage quantity (usage - included).
+    pub overage: Option<u64>,
+    /// Charges for this metric.
+    pub charges: Decimal,
+}
+
+impl MetricUsage {
+    /// Validates the metric usage.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if `current_usage` exceeds maximum allowed value.
+    pub fn validate(&self) -> Result<()> {
+        if self.current_usage > MAX_USAGE_QUANTITY {
+            return Err(BridgeError::UsageError(format!(
+                "Current usage {} exceeds maximum allowed value of {MAX_USAGE_QUANTITY}",
+                self.current_usage
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // PlanId Tests
+    // ========================================================================
+
+    #[test]
+    fn test_plan_id_valid() {
+        let id = PlanId::new("plan-123").unwrap();
+        assert_eq!(id.as_str(), "plan-123");
+    }
+
+    #[test]
+    fn test_plan_id_empty_rejected() {
+        let result = PlanId::new("");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BridgeError::InvalidPlanId(_)));
+    }
+
+    #[test]
+    fn test_plan_id_too_long_rejected() {
+        let long_id = "a".repeat(65);
+        let result = PlanId::new(long_id);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BridgeError::InvalidPlanId(_)));
+    }
+
+    #[test]
+    fn test_plan_id_exactly_64_chars_accepted() {
+        let exactly_64 = "a".repeat(64);
+        let result = PlanId::new(exactly_64.clone());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), exactly_64);
+    }
+
+    #[test]
+    fn test_plan_id_single_char_accepted() {
+        let id = PlanId::new("a").unwrap();
+        assert_eq!(id.as_str(), "a");
+    }
+
+    #[test]
+    fn test_plan_id_rejects_path_traversal() {
+        let result = PlanId::new("../etc/passwd");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BridgeError::InvalidPlanId(_)));
+    }
+
+    #[test]
+    fn test_plan_id_rejects_slash() {
+        let result = PlanId::new("plan/123");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_plan_id_accepts_valid_chars() {
+        let result = PlanId::new("plan-123_ABC");
+        assert!(result.is_ok());
+    }
+
+    // ========================================================================
+    // SubscriptionId Tests
+    // ========================================================================
+
+    #[test]
+    fn test_subscription_id_valid() {
+        let id = SubscriptionId::new("sub-456").unwrap();
+        assert_eq!(id.as_str(), "sub-456");
+    }
+
+    #[test]
+    fn test_subscription_id_empty_rejected() {
+        let result = SubscriptionId::new("");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BridgeError::InvalidSubscriptionId(_)));
+    }
+
+    #[test]
+    fn test_subscription_id_too_long_rejected() {
+        let long_id = "b".repeat(65);
+        let result = SubscriptionId::new(long_id);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BridgeError::InvalidSubscriptionId(_)));
+    }
+
+    #[test]
+    fn test_subscription_id_exactly_64_chars_accepted() {
+        let exactly_64 = "b".repeat(64);
+        let result = SubscriptionId::new(exactly_64.clone());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), exactly_64);
+    }
+
+    #[test]
+    fn test_subscription_id_rejects_special_chars() {
+        let result = SubscriptionId::new("sub@123");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_subscription_id_rejects_whitespace() {
+        let result = SubscriptionId::new("sub 123");
+        assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // BillingCycle Tests
+    // ========================================================================
+
+    #[test]
+    fn test_billing_cycle_monthly_display() {
+        let cycle = BillingCycle::Monthly { anchor_day: 1 };
+        assert_eq!(cycle.interval_display(), "month");
+    }
+
+    #[test]
+    fn test_billing_cycle_annual_display() {
+        let cycle = BillingCycle::Annual { anchor_month: 1, anchor_day: 1 };
+        assert_eq!(cycle.interval_display(), "year");
+    }
+
+    #[test]
+    fn test_billing_cycle_weekly_display() {
+        let cycle = BillingCycle::Weekly { anchor_day: 1 };
+        assert_eq!(cycle.interval_display(), "week");
+    }
+
+    #[test]
+    fn test_billing_cycle_custom_single_day_display() {
+        let cycle = BillingCycle::Custom { interval_days: 1 };
+        assert_eq!(cycle.interval_display(), "day");
+    }
+
+    #[test]
+    fn test_billing_cycle_custom_multi_day_display() {
+        let cycle = BillingCycle::Custom { interval_days: 30 };
+        assert_eq!(cycle.interval_display(), "custom period");
+    }
+
+    #[test]
+    fn test_billing_cycle_onetime_display() {
+        let cycle = BillingCycle::OneTime { validity_days: None };
+        assert_eq!(cycle.interval_display(), "one-time");
+    }
+
+    #[test]
+    fn test_billing_cycle_serialization() {
+        let monthly = BillingCycle::Monthly { anchor_day: 15 };
+        let json = serde_json::to_string(&monthly).unwrap();
+        assert!(json.contains("\"type\":\"monthly\""));
+        assert!(json.contains("\"anchor_day\":15"));
+
+        let parsed: BillingCycle = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, monthly);
+    }
+
+    #[test]
+    fn test_billing_cycle_deserialization() {
+        let json = r#"{"type":"annual","anchor_month":6,"anchor_day":15}"#;
+        let cycle: BillingCycle = serde_json::from_str(json).unwrap();
+        assert_eq!(cycle, BillingCycle::Annual { anchor_month: 6, anchor_day: 15 });
+    }
+
+    // ========================================================================
+    // UsageAction Tests
+    // ========================================================================
+
+    #[test]
+    fn test_usage_action_set_serialization() {
+        let action = UsageAction::Set;
+        let json = serde_json::to_string(&action).unwrap();
+        assert_eq!(json, "\"set\"");
+    }
+
+    #[test]
+    fn test_usage_action_increment_serialization() {
+        let action = UsageAction::Increment;
+        let json = serde_json::to_string(&action).unwrap();
+        assert_eq!(json, "\"increment\"");
+    }
+
+    #[test]
+    fn test_usage_action_deserialization() {
+        let set: UsageAction = serde_json::from_str("\"set\"").unwrap();
+        assert_eq!(set, UsageAction::Set);
+
+        let increment: UsageAction = serde_json::from_str("\"increment\"").unwrap();
+        assert_eq!(increment, UsageAction::Increment);
+    }
+}

--- a/tap-mcp-bridge/src/mcp/subscriptions/pricing.rs
+++ b/tap-mcp-bridge/src/mcp/subscriptions/pricing.rs
@@ -1,0 +1,468 @@
+//! Pricing models for subscription plans.
+//!
+//! Supports flat-rate, tiered, per-seat, usage-based, and hybrid pricing.
+
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+/// Pricing model for a subscription plan.
+///
+/// Each variant represents a different pricing strategy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum PricingModel {
+    /// Fixed price per billing cycle.
+    ///
+    /// Example: $9.99/month, $99/year
+    FlatRate(FlatRatePrice),
+
+    /// Different price tiers based on plan level.
+    ///
+    /// Example: Basic $10, Pro $25, Enterprise $100
+    Tiered(TieredPrice),
+
+    /// Price per unit (seat, user, license).
+    ///
+    /// Example: $5/user/month
+    PerSeat(PerSeatPrice),
+
+    /// Price based on usage metrics.
+    ///
+    /// Example: $0.01/API call, $0.10/GB
+    UsageBased(UsageBasedPrice),
+
+    /// Combination of base price plus usage/overage.
+    ///
+    /// Example: Base $20 + $0.05/API call over 1000
+    Hybrid(HybridPrice),
+}
+
+impl PricingModel {
+    /// Returns the minimum price per billing cycle.
+    ///
+    /// For usage-based models, returns the base/minimum commitment.
+    #[must_use]
+    pub fn minimum_price(&self) -> Decimal {
+        match self {
+            Self::FlatRate(p) => p.amount,
+            Self::Tiered(p) => p.tiers.first().map_or(Decimal::ZERO, |t| t.price),
+            Self::PerSeat(p) => p.price_per_seat * Decimal::from(p.minimum_seats.unwrap_or(1)),
+            Self::UsageBased(p) => p.minimum_commitment.unwrap_or(Decimal::ZERO),
+            Self::Hybrid(p) => p.base_price,
+        }
+    }
+}
+
+/// Flat-rate pricing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlatRatePrice {
+    /// Price per billing cycle.
+    pub amount: Decimal,
+    /// Setup fee (charged once at subscription start).
+    pub setup_fee: Option<Decimal>,
+}
+
+/// Tiered pricing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TieredPrice {
+    /// Available tiers (ordered by level).
+    pub tiers: Vec<PriceTier>,
+    /// Whether tiers are mutually exclusive or cumulative.
+    pub tier_mode: TierMode,
+}
+
+/// Single price tier.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PriceTier {
+    /// Tier identifier.
+    pub id: String,
+    /// Display name (e.g., "Basic", "Pro", "Enterprise").
+    pub name: String,
+    /// Price for this tier per billing cycle.
+    pub price: Decimal,
+    /// Maximum usage/seats included (None = unlimited).
+    pub up_to: Option<u64>,
+    /// Features specific to this tier.
+    pub features: Vec<String>,
+}
+
+/// How tiers are calculated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TierMode {
+    /// Each tier has fixed price (select one tier).
+    Volume,
+    /// Units are distributed across tiers (graduated pricing).
+    Graduated,
+}
+
+/// Per-seat (per-user/license) pricing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PerSeatPrice {
+    /// Price per seat per billing cycle.
+    pub price_per_seat: Decimal,
+    /// Minimum seats required.
+    pub minimum_seats: Option<u32>,
+    /// Maximum seats allowed (None = unlimited).
+    pub maximum_seats: Option<u32>,
+    /// Volume discount tiers.
+    pub volume_discounts: Vec<VolumeDiscount>,
+}
+
+/// Volume discount for per-seat pricing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VolumeDiscount {
+    /// Minimum seats to qualify for discount.
+    pub min_seats: u32,
+    /// Discount percentage (0-100).
+    pub discount_percent: Decimal,
+}
+
+/// Usage-based pricing configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageBasedPrice {
+    /// Metric being measured.
+    pub metric: UsageMetric,
+    /// Price per unit of usage.
+    pub price_per_unit: Decimal,
+    /// Minimum commitment per billing cycle.
+    pub minimum_commitment: Option<Decimal>,
+    /// Tiered pricing for usage (graduated pricing).
+    pub usage_tiers: Vec<UsageTier>,
+}
+
+/// Usage metric definition.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageMetric {
+    /// Metric identifier.
+    pub id: String,
+    /// Display name (e.g., "API Calls", "Storage").
+    pub name: String,
+    /// Unit of measurement (e.g., "calls", "GB", "requests").
+    pub unit: String,
+    /// How usage is aggregated within billing cycle.
+    pub aggregation: UsageAggregation,
+}
+
+/// How usage is aggregated for billing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageAggregation {
+    /// Sum of all usage in period.
+    Sum,
+    /// Maximum usage at any point in period.
+    Max,
+    /// Last recorded value in period.
+    LastValue,
+    /// Average across period.
+    Average,
+}
+
+/// Usage tier for graduated pricing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageTier {
+    /// Start of tier (units).
+    pub from: u64,
+    /// End of tier (units, None = unlimited).
+    pub up_to: Option<u64>,
+    /// Price per unit in this tier.
+    pub price_per_unit: Decimal,
+}
+
+/// Hybrid pricing configuration (base + usage/overage).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HybridPrice {
+    /// Base price per billing cycle.
+    pub base_price: Decimal,
+    /// Included usage before overage charges.
+    pub included_usage: IncludedUsage,
+    /// Overage pricing when included usage exceeded.
+    pub overage_pricing: OveragePricing,
+}
+
+/// Usage included in base price.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IncludedUsage {
+    /// Metric being measured.
+    pub metric: UsageMetric,
+    /// Quantity included in base price.
+    pub quantity: u64,
+}
+
+/// Pricing for usage exceeding included amount.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OveragePricing {
+    /// Price per unit of overage.
+    pub price_per_unit: Decimal,
+    /// Maximum overage allowed (hard cap).
+    pub max_overage: Option<u64>,
+    /// Whether overage is billed in arrears or immediately.
+    pub bill_immediately: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // FlatRate Tests
+    // ========================================================================
+
+    #[test]
+    fn test_flat_rate_minimum_price() {
+        let pricing =
+            PricingModel::FlatRate(FlatRatePrice { amount: Decimal::new(999, 2), setup_fee: None });
+        assert_eq!(pricing.minimum_price(), Decimal::new(999, 2));
+    }
+
+    #[test]
+    fn test_flat_rate_with_setup_fee() {
+        let pricing = PricingModel::FlatRate(FlatRatePrice {
+            amount: Decimal::new(1000, 2),
+            setup_fee: Some(Decimal::new(500, 2)),
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::new(1000, 2));
+    }
+
+    // ========================================================================
+    // Tiered Tests
+    // ========================================================================
+
+    #[test]
+    fn test_tiered_minimum_price_empty_tiers() {
+        let pricing =
+            PricingModel::Tiered(TieredPrice { tiers: vec![], tier_mode: TierMode::Volume });
+        assert_eq!(pricing.minimum_price(), Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_tiered_minimum_price_single_tier() {
+        let pricing = PricingModel::Tiered(TieredPrice {
+            tiers: vec![PriceTier {
+                id: "basic".to_owned(),
+                name: "Basic".to_owned(),
+                price: Decimal::new(1500, 2),
+                up_to: Some(100),
+                features: vec![],
+            }],
+            tier_mode: TierMode::Volume,
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::new(1500, 2));
+    }
+
+    #[test]
+    fn test_tiered_minimum_price_multiple_tiers() {
+        let pricing = PricingModel::Tiered(TieredPrice {
+            tiers: vec![
+                PriceTier {
+                    id: "basic".to_owned(),
+                    name: "Basic".to_owned(),
+                    price: Decimal::new(1000, 2),
+                    up_to: Some(100),
+                    features: vec![],
+                },
+                PriceTier {
+                    id: "pro".to_owned(),
+                    name: "Pro".to_owned(),
+                    price: Decimal::new(2500, 2),
+                    up_to: Some(500),
+                    features: vec![],
+                },
+                PriceTier {
+                    id: "enterprise".to_owned(),
+                    name: "Enterprise".to_owned(),
+                    price: Decimal::new(5000, 2),
+                    up_to: None,
+                    features: vec![],
+                },
+            ],
+            tier_mode: TierMode::Graduated,
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::new(1000, 2));
+    }
+
+    // ========================================================================
+    // PerSeat Tests
+    // ========================================================================
+
+    #[test]
+    fn test_per_seat_minimum_price_with_minimum() {
+        let pricing = PricingModel::PerSeat(PerSeatPrice {
+            price_per_seat: Decimal::new(500, 2),
+            minimum_seats: Some(5),
+            maximum_seats: None,
+            volume_discounts: vec![],
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::new(2500, 2));
+    }
+
+    #[test]
+    fn test_per_seat_minimum_price_no_minimum() {
+        let pricing = PricingModel::PerSeat(PerSeatPrice {
+            price_per_seat: Decimal::new(500, 2),
+            minimum_seats: None,
+            maximum_seats: Some(100),
+            volume_discounts: vec![],
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::new(500, 2));
+    }
+
+    #[test]
+    fn test_per_seat_minimum_price_zero_seats() {
+        let pricing = PricingModel::PerSeat(PerSeatPrice {
+            price_per_seat: Decimal::new(500, 2),
+            minimum_seats: Some(0),
+            maximum_seats: None,
+            volume_discounts: vec![],
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::ZERO);
+    }
+
+    // ========================================================================
+    // UsageBased Tests
+    // ========================================================================
+
+    #[test]
+    fn test_usage_based_minimum_price_with_commitment() {
+        let pricing = PricingModel::UsageBased(UsageBasedPrice {
+            metric: UsageMetric {
+                id: "api_calls".to_owned(),
+                name: "API Calls".to_owned(),
+                unit: "calls".to_owned(),
+                aggregation: UsageAggregation::Sum,
+            },
+            price_per_unit: Decimal::new(1, 2),
+            minimum_commitment: Some(Decimal::new(10000, 2)),
+            usage_tiers: vec![],
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::new(10000, 2));
+    }
+
+    #[test]
+    fn test_usage_based_minimum_price_no_commitment() {
+        let pricing = PricingModel::UsageBased(UsageBasedPrice {
+            metric: UsageMetric {
+                id: "storage".to_owned(),
+                name: "Storage".to_owned(),
+                unit: "GB".to_owned(),
+                aggregation: UsageAggregation::Max,
+            },
+            price_per_unit: Decimal::new(10, 2),
+            minimum_commitment: None,
+            usage_tiers: vec![],
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::ZERO);
+    }
+
+    // ========================================================================
+    // Hybrid Tests
+    // ========================================================================
+
+    #[test]
+    fn test_hybrid_minimum_price() {
+        let pricing = PricingModel::Hybrid(HybridPrice {
+            base_price: Decimal::new(2000, 2),
+            included_usage: IncludedUsage {
+                metric: UsageMetric {
+                    id: "api_calls".to_owned(),
+                    name: "API Calls".to_owned(),
+                    unit: "calls".to_owned(),
+                    aggregation: UsageAggregation::Sum,
+                },
+                quantity: 1000,
+            },
+            overage_pricing: OveragePricing {
+                price_per_unit: Decimal::new(5, 2),
+                max_overage: None,
+                bill_immediately: false,
+            },
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::new(2000, 2));
+    }
+
+    #[test]
+    fn test_hybrid_zero_base_price() {
+        let pricing = PricingModel::Hybrid(HybridPrice {
+            base_price: Decimal::ZERO,
+            included_usage: IncludedUsage {
+                metric: UsageMetric {
+                    id: "requests".to_owned(),
+                    name: "Requests".to_owned(),
+                    unit: "requests".to_owned(),
+                    aggregation: UsageAggregation::Sum,
+                },
+                quantity: 0,
+            },
+            overage_pricing: OveragePricing {
+                price_per_unit: Decimal::new(1, 2),
+                max_overage: Some(10000),
+                bill_immediately: true,
+            },
+        });
+        assert_eq!(pricing.minimum_price(), Decimal::ZERO);
+    }
+
+    // ========================================================================
+    // Serialization Tests
+    // ========================================================================
+
+    #[test]
+    fn test_tier_mode_volume_serialization() {
+        let mode = TierMode::Volume;
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, "\"volume\"");
+    }
+
+    #[test]
+    fn test_tier_mode_graduated_serialization() {
+        let mode = TierMode::Graduated;
+        let json = serde_json::to_string(&mode).unwrap();
+        assert_eq!(json, "\"graduated\"");
+    }
+
+    #[test]
+    fn test_usage_aggregation_sum_serialization() {
+        let agg = UsageAggregation::Sum;
+        let json = serde_json::to_string(&agg).unwrap();
+        assert_eq!(json, "\"sum\"");
+    }
+
+    #[test]
+    fn test_usage_aggregation_max_serialization() {
+        let agg = UsageAggregation::Max;
+        let json = serde_json::to_string(&agg).unwrap();
+        assert_eq!(json, "\"max\"");
+    }
+
+    #[test]
+    fn test_usage_aggregation_last_value_serialization() {
+        let agg = UsageAggregation::LastValue;
+        let json = serde_json::to_string(&agg).unwrap();
+        assert_eq!(json, "\"last_value\"");
+    }
+
+    #[test]
+    fn test_usage_aggregation_average_serialization() {
+        let agg = UsageAggregation::Average;
+        let json = serde_json::to_string(&agg).unwrap();
+        assert_eq!(json, "\"average\"");
+    }
+
+    #[test]
+    fn test_pricing_model_serialization_flat_rate() {
+        let pricing = PricingModel::FlatRate(FlatRatePrice {
+            amount: Decimal::new(999, 2),
+            setup_fee: Some(Decimal::new(100, 2)),
+        });
+        let json = serde_json::to_string(&pricing).unwrap();
+        assert!(json.contains("\"type\":\"flat_rate\""));
+    }
+
+    #[test]
+    fn test_pricing_model_serialization_tiered() {
+        let pricing =
+            PricingModel::Tiered(TieredPrice { tiers: vec![], tier_mode: TierMode::Volume });
+        let json = serde_json::to_string(&pricing).unwrap();
+        assert!(json.contains("\"type\":\"tiered\""));
+    }
+}

--- a/tap-mcp-bridge/src/mcp/subscriptions/proration.rs
+++ b/tap-mcp-bridge/src/mcp/subscriptions/proration.rs
@@ -1,0 +1,483 @@
+//! Proration calculation utilities.
+//!
+//! Provides helpers for calculating prorated credits and charges
+//! when subscriptions change mid-cycle.
+
+use chrono::{DateTime, Datelike, Duration, Utc};
+use rust_decimal::Decimal;
+
+use super::models::BillingCycle;
+use crate::error::{BridgeError, Result};
+
+/// Calculates prorated credit for unused time in current period.
+///
+/// # Arguments
+///
+/// * `current_period_start` - Start of the current billing period
+/// * `current_period_end` - End of the current billing period
+/// * `change_date` - When the change takes effect
+/// * `current_amount` - Amount paid for the current period
+///
+/// # Returns
+///
+/// Credit amount for unused time
+///
+/// # Errors
+///
+/// Returns error if dates are invalid (`change_date` before `period_start` or after `period_end`).
+///
+/// # Examples
+///
+/// ```
+/// use chrono::Utc;
+/// use rust_decimal::Decimal;
+/// use tap_mcp_bridge::mcp::subscriptions::proration::calculate_credit;
+///
+/// # fn example() -> tap_mcp_bridge::error::Result<()> {
+/// let period_start = Utc::now();
+/// let period_end = period_start + chrono::Duration::days(30);
+/// let change_date = period_start + chrono::Duration::days(15);
+/// let current_amount = Decimal::new(3000, 2); // $30.00
+///
+/// let credit = calculate_credit(period_start, period_end, change_date, current_amount)?;
+/// # Ok(())
+/// # }
+/// ```
+pub fn calculate_credit(
+    current_period_start: DateTime<Utc>,
+    current_period_end: DateTime<Utc>,
+    change_date: DateTime<Utc>,
+    current_amount: Decimal,
+) -> Result<Decimal> {
+    if change_date < current_period_start || change_date > current_period_end {
+        return Err(BridgeError::ProrationError(
+            "change_date must be within current billing period".to_owned(),
+        ));
+    }
+
+    let total_duration = (current_period_end - current_period_start).num_seconds();
+    let unused_duration = (current_period_end - change_date).num_seconds();
+
+    if total_duration == 0 {
+        return Ok(Decimal::ZERO);
+    }
+
+    let proration_factor = Decimal::from(unused_duration) / Decimal::from(total_duration);
+
+    current_amount
+        .checked_mul(proration_factor)
+        .ok_or_else(|| BridgeError::ProrationError("Overflow in credit calculation".into()))
+}
+
+/// Calculates prorated charge for new plan/quantity starting mid-cycle.
+///
+/// # Arguments
+///
+/// * `current_period_start` - Start of the current billing period
+/// * `current_period_end` - End of the current billing period
+/// * `change_date` - When the change takes effect
+/// * `new_amount` - Amount for the new plan/quantity per period
+///
+/// # Returns
+///
+/// Prorated charge amount for the remaining period
+///
+/// # Errors
+///
+/// Returns error if dates are invalid.
+pub fn calculate_charge(
+    current_period_start: DateTime<Utc>,
+    current_period_end: DateTime<Utc>,
+    change_date: DateTime<Utc>,
+    new_amount: Decimal,
+) -> Result<Decimal> {
+    if change_date < current_period_start || change_date > current_period_end {
+        return Err(BridgeError::ProrationError(
+            "change_date must be within current billing period".to_owned(),
+        ));
+    }
+
+    let total_duration = (current_period_end - current_period_start).num_seconds();
+    let remaining_duration = (current_period_end - change_date).num_seconds();
+
+    if total_duration == 0 {
+        return Ok(Decimal::ZERO);
+    }
+
+    let proration_factor = Decimal::from(remaining_duration) / Decimal::from(total_duration);
+
+    new_amount
+        .checked_mul(proration_factor)
+        .ok_or_else(|| BridgeError::ProrationError("Overflow in charge calculation".into()))
+}
+
+/// Calculates the next billing date based on billing cycle.
+///
+/// # Arguments
+///
+/// * `current_date` - Current date/time
+/// * `cycle` - Billing cycle configuration
+///
+/// # Returns
+///
+/// Next billing date
+#[must_use]
+pub fn calculate_next_billing_date(
+    current_date: DateTime<Utc>,
+    cycle: &BillingCycle,
+) -> DateTime<Utc> {
+    match cycle {
+        BillingCycle::Monthly { anchor_day } => {
+            let mut next_date = current_date;
+            let target_day = u32::from((*anchor_day).min(28));
+
+            if current_date.day() >= target_day {
+                next_date += Duration::days(32);
+            }
+
+            next_date.with_day(target_day).unwrap_or(next_date)
+        }
+        BillingCycle::Annual { anchor_month, anchor_day } => {
+            let mut next_date = current_date;
+            let target_month = u32::from((*anchor_month).min(12));
+            let target_day = u32::from((*anchor_day).min(28));
+
+            if current_date.month() > target_month
+                || (current_date.month() == target_month && current_date.day() >= target_day)
+            {
+                next_date += Duration::days(366);
+            }
+
+            next_date
+                .with_month(target_month)
+                .and_then(|d| d.with_day(target_day))
+                .unwrap_or(next_date)
+        }
+        BillingCycle::Weekly { anchor_day } => {
+            let current_weekday = current_date.weekday().num_days_from_sunday();
+            let target_weekday = u32::from(*anchor_day).min(6);
+
+            let days_until_target = if current_weekday < target_weekday {
+                target_weekday - current_weekday
+            } else {
+                7 - (current_weekday - target_weekday)
+            };
+
+            current_date + Duration::days(i64::from(days_until_target))
+        }
+        BillingCycle::Custom { interval_days } => {
+            current_date + Duration::days(i64::from(*interval_days))
+        }
+        BillingCycle::OneTime { .. } => current_date,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // Credit Calculation Tests
+    // ========================================================================
+
+    #[test]
+    fn test_calculate_credit_half_period() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = start + Duration::days(15);
+        let amount = Decimal::new(3000, 2);
+
+        let credit = calculate_credit(start, end, change, amount).unwrap();
+        assert!(credit > Decimal::new(1400, 2));
+        assert!(credit < Decimal::new(1600, 2));
+    }
+
+    #[test]
+    fn test_calculate_credit_end_of_period() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = end;
+        let amount = Decimal::new(3000, 2);
+
+        let credit = calculate_credit(start, end, change, amount).unwrap();
+        assert_eq!(credit, Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_calculate_credit_start_of_period() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = start;
+        let amount = Decimal::new(3000, 2);
+
+        let credit = calculate_credit(start, end, change, amount).unwrap();
+        assert_eq!(credit, amount);
+    }
+
+    #[test]
+    fn test_calculate_credit_invalid_date_before_start() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = start - Duration::days(1);
+        let amount = Decimal::new(3000, 2);
+
+        let result = calculate_credit(start, end, change, amount);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BridgeError::ProrationError(_)));
+    }
+
+    #[test]
+    fn test_calculate_credit_invalid_date_after_end() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = end + Duration::days(1);
+        let amount = Decimal::new(3000, 2);
+
+        let result = calculate_credit(start, end, change, amount);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_calculate_credit_zero_duration_period() {
+        let now = Utc::now();
+        let amount = Decimal::new(3000, 2);
+
+        let credit = calculate_credit(now, now, now, amount).unwrap();
+        assert_eq!(credit, Decimal::ZERO);
+    }
+
+    // ========================================================================
+    // Charge Calculation Tests
+    // ========================================================================
+
+    #[test]
+    fn test_calculate_charge_half_period() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = start + Duration::days(15);
+        let amount = Decimal::new(5000, 2);
+
+        let charge = calculate_charge(start, end, change, amount).unwrap();
+        assert!(charge > Decimal::new(2400, 2));
+        assert!(charge < Decimal::new(2600, 2));
+    }
+
+    #[test]
+    fn test_calculate_charge_start_of_period() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = start;
+        let amount = Decimal::new(5000, 2);
+
+        let charge = calculate_charge(start, end, change, amount).unwrap();
+        assert_eq!(charge, amount);
+    }
+
+    #[test]
+    fn test_calculate_charge_end_of_period() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = end;
+        let amount = Decimal::new(5000, 2);
+
+        let charge = calculate_charge(start, end, change, amount).unwrap();
+        assert_eq!(charge, Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_calculate_charge_invalid_date_before_start() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = start - Duration::days(1);
+        let amount = Decimal::new(5000, 2);
+
+        let result = calculate_charge(start, end, change, amount);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_calculate_charge_invalid_date_after_end() {
+        let start = Utc::now();
+        let end = start + Duration::days(30);
+        let change = end + Duration::days(1);
+        let amount = Decimal::new(5000, 2);
+
+        let result = calculate_charge(start, end, change, amount);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_calculate_charge_zero_duration_period() {
+        let now = Utc::now();
+        let amount = Decimal::new(5000, 2);
+
+        let charge = calculate_charge(now, now, now, amount).unwrap();
+        assert_eq!(charge, Decimal::ZERO);
+    }
+
+    // ========================================================================
+    // Next Billing Date Tests - Monthly
+    // ========================================================================
+
+    #[test]
+    fn test_calculate_next_billing_date_monthly() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Monthly { anchor_day: 15 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        assert!(next.day() <= 15);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_monthly_anchor_day_28() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Monthly { anchor_day: 28 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        assert!(next.day() <= 28);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_monthly_anchor_day_clamped() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Monthly { anchor_day: 31 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        assert!(next.day() <= 28);
+    }
+
+    // ========================================================================
+    // Next Billing Date Tests - Annual
+    // ========================================================================
+
+    #[test]
+    fn test_calculate_next_billing_date_annual() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Annual { anchor_month: 6, anchor_day: 15 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_annual_month_clamped() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Annual { anchor_month: 13, anchor_day: 15 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        assert!(next.month() <= 12);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_annual_day_clamped() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Annual { anchor_month: 6, anchor_day: 31 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        assert!(next.day() <= 28);
+    }
+
+    // ========================================================================
+    // Next Billing Date Tests - Weekly
+    // ========================================================================
+
+    #[test]
+    fn test_calculate_next_billing_date_weekly_monday() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Weekly { anchor_day: 1 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        let days_diff = (next - current).num_days();
+        assert!(days_diff <= 7);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_weekly_sunday() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Weekly { anchor_day: 0 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        let days_diff = (next - current).num_days();
+        assert!(days_diff <= 7);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_weekly_saturday() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Weekly { anchor_day: 6 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+        let days_diff = (next - current).num_days();
+        assert!(days_diff <= 7);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_weekly_anchor_clamped() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Weekly { anchor_day: 10 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert!(next >= current);
+    }
+
+    // ========================================================================
+    // Next Billing Date Tests - Custom
+    // ========================================================================
+
+    #[test]
+    fn test_calculate_next_billing_date_custom_interval() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Custom { interval_days: 14 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert_eq!((next - current).num_days(), 14);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_custom_single_day() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Custom { interval_days: 1 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert_eq!((next - current).num_days(), 1);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_custom_large_interval() {
+        let current = Utc::now();
+        let cycle = BillingCycle::Custom { interval_days: 365 };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert_eq!((next - current).num_days(), 365);
+    }
+
+    // ========================================================================
+    // Next Billing Date Tests - OneTime
+    // ========================================================================
+
+    #[test]
+    fn test_calculate_next_billing_date_onetime_no_validity() {
+        let current = Utc::now();
+        let cycle = BillingCycle::OneTime { validity_days: None };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert_eq!(next, current);
+    }
+
+    #[test]
+    fn test_calculate_next_billing_date_onetime_with_validity() {
+        let current = Utc::now();
+        let cycle = BillingCycle::OneTime { validity_days: Some(30) };
+
+        let next = calculate_next_billing_date(current, &cycle);
+        assert_eq!(next, current);
+    }
+}

--- a/tap-mcp-bridge/src/mcp/subscriptions/tools.rs
+++ b/tap-mcp-bridge/src/mcp/subscriptions/tools.rs
@@ -1,0 +1,1183 @@
+//! MCP tools for subscription management.
+//!
+//! Provides TAP-authenticated subscription operations.
+
+use std::{sync::LazyLock, time::Duration};
+
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use tracing::{info, instrument};
+
+use super::{
+    lifecycle::SubscriptionResponse,
+    models::{PlanCatalog, SubscriptionPlan, UsageAction, UsageRecord, UsageSummary},
+};
+use crate::{
+    error::Result,
+    mcp::{
+        http::{HttpMethod, build_url_with_query, execute_tap_request_with_acro},
+        models::Address,
+    },
+    tap::{InteractionType, TapSigner, acro::ContextualData},
+};
+
+/// Timeout for subscription HTTP requests in seconds.
+const SUBSCRIPTION_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Shared HTTP client for all subscription requests.
+///
+/// This static client is initialized once and reused across all requests,
+/// providing connection pooling and reducing per-request overhead.
+static SUBSCRIPTION_HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(SUBSCRIPTION_REQUEST_TIMEOUT_SECS))
+        .pool_max_idle_per_host(100)
+        .http2_prior_knowledge()
+        .build()
+        .expect("failed to create subscription HTTP client")
+});
+
+// ============================================================================
+// Tool Parameters
+// ============================================================================
+
+/// Parameters for retrieving subscription plans.
+#[derive(Debug, Deserialize)]
+pub struct GetPlansParams {
+    /// Merchant URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Filter by billing cycle type.
+    pub billing_cycle: Option<String>,
+    /// Filter by pricing model type.
+    pub pricing_type: Option<String>,
+    /// Include inactive plans.
+    pub include_inactive: Option<bool>,
+    /// Page number.
+    pub page: Option<u32>,
+    /// Items per page.
+    pub per_page: Option<u32>,
+    /// Country code for ACRO contextual data (ISO 3166-1 alpha-2).
+    pub country_code: String,
+    /// Postal/ZIP code for ACRO contextual data.
+    pub zip: String,
+    /// Client IP address for ACRO contextual data.
+    pub ip_address: String,
+    /// User agent string for ACRO contextual data.
+    pub user_agent: String,
+    /// Platform identifier for ACRO contextual data.
+    pub platform: String,
+}
+
+/// Parameters for retrieving a single plan.
+#[derive(Debug, Deserialize)]
+pub struct GetPlanParams {
+    /// Merchant URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Plan identifier.
+    pub plan_id: String,
+    /// Country code for ACRO contextual data (ISO 3166-1 alpha-2).
+    pub country_code: String,
+    /// Postal/ZIP code for ACRO contextual data.
+    pub zip: String,
+    /// Client IP address for ACRO contextual data.
+    pub ip_address: String,
+    /// User agent string for ACRO contextual data.
+    pub user_agent: String,
+    /// Platform identifier for ACRO contextual data.
+    pub platform: String,
+}
+
+/// Parameters for creating a subscription.
+#[derive(Debug, Deserialize)]
+pub struct CreateSubscriptionParams {
+    /// Merchant URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Plan identifier.
+    pub plan_id: String,
+    /// Initial quantity (seats, licenses).
+    pub quantity: Option<u32>,
+    /// Whether to start with trial (if available).
+    pub start_trial: Option<bool>,
+    /// Billing address.
+    pub billing_address: Option<Address>,
+    /// Payment method (encrypted via APC).
+    pub payment_method: Option<crate::mcp::payment::PaymentMethodParams>,
+    /// Merchant RSA public key for APC.
+    pub merchant_public_key_pem: Option<String>,
+    /// Promo code.
+    pub promo_code: Option<String>,
+    /// Country code for ACRO contextual data (ISO 3166-1 alpha-2).
+    pub country_code: String,
+    /// Postal/ZIP code for ACRO contextual data.
+    pub zip: String,
+    /// Client IP address for ACRO contextual data.
+    pub ip_address: String,
+    /// User agent string for ACRO contextual data.
+    pub user_agent: String,
+    /// Platform identifier for ACRO contextual data.
+    pub platform: String,
+}
+
+/// Parameters for retrieving a subscription.
+#[derive(Debug, Deserialize)]
+pub struct GetSubscriptionParams {
+    /// Merchant URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// Country code for ACRO contextual data (ISO 3166-1 alpha-2).
+    pub country_code: String,
+    /// Postal/ZIP code for ACRO contextual data.
+    pub zip: String,
+    /// Client IP address for ACRO contextual data.
+    pub ip_address: String,
+    /// User agent string for ACRO contextual data.
+    pub user_agent: String,
+    /// Platform identifier for ACRO contextual data.
+    pub platform: String,
+}
+
+/// Parameters for updating a subscription.
+#[derive(Debug, Deserialize)]
+pub struct UpdateSubscriptionParams {
+    /// Merchant URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// New quantity (triggers proration).
+    pub quantity: Option<u32>,
+    /// New plan ID (upgrade/downgrade).
+    pub plan_id: Option<String>,
+    /// Proration behavior.
+    pub proration_behavior: Option<ProrationBehavior>,
+    /// Country code for ACRO contextual data (ISO 3166-1 alpha-2).
+    pub country_code: String,
+    /// Postal/ZIP code for ACRO contextual data.
+    pub zip: String,
+    /// Client IP address for ACRO contextual data.
+    pub ip_address: String,
+    /// User agent string for ACRO contextual data.
+    pub user_agent: String,
+    /// Platform identifier for ACRO contextual data.
+    pub platform: String,
+}
+
+/// Proration behavior for mid-cycle changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProrationBehavior {
+    /// Create prorated invoice immediately.
+    CreateProrations,
+    /// Apply proration to next invoice.
+    None,
+    /// Always charge full price (no credit).
+    AlwaysInvoice,
+}
+
+/// Parameters for canceling a subscription.
+#[derive(Debug, Deserialize)]
+pub struct CancelSubscriptionParams {
+    /// Merchant URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// Cancel immediately or at period end.
+    pub cancel_at_period_end: Option<bool>,
+    /// Cancellation reason.
+    pub reason: Option<String>,
+    /// Request refund for unused time.
+    pub request_refund: Option<bool>,
+    /// Country code for ACRO contextual data (ISO 3166-1 alpha-2).
+    pub country_code: String,
+    /// Postal/ZIP code for ACRO contextual data.
+    pub zip: String,
+    /// Client IP address for ACRO contextual data.
+    pub ip_address: String,
+    /// User agent string for ACRO contextual data.
+    pub user_agent: String,
+    /// Platform identifier for ACRO contextual data.
+    pub platform: String,
+}
+
+/// Parameters for pausing a subscription.
+#[derive(Debug, Deserialize)]
+pub struct PauseSubscriptionParams {
+    /// Merchant base URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// When to automatically resume (optional).
+    pub resume_at: Option<DateTime<Utc>>,
+    /// Pause reason.
+    pub reason: Option<String>,
+    /// Consumer country code (ACRO contextual data).
+    pub country_code: String,
+    /// Consumer postal/ZIP code (ACRO contextual data).
+    pub zip: String,
+    /// Consumer IP address (ACRO contextual data).
+    pub ip_address: String,
+    /// Consumer user agent (ACRO contextual data).
+    pub user_agent: String,
+    /// Consumer platform (ACRO contextual data).
+    pub platform: String,
+}
+
+/// Parameters for resuming a subscription.
+#[derive(Debug, Deserialize)]
+pub struct ResumeSubscriptionParams {
+    /// Merchant base URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// Whether to charge immediately for resumed period.
+    pub charge_immediately: Option<bool>,
+    /// Consumer country code (ACRO contextual data).
+    pub country_code: String,
+    /// Consumer postal/ZIP code (ACRO contextual data).
+    pub zip: String,
+    /// Consumer IP address (ACRO contextual data).
+    pub ip_address: String,
+    /// Consumer user agent (ACRO contextual data).
+    pub user_agent: String,
+    /// Consumer platform (ACRO contextual data).
+    pub platform: String,
+}
+
+/// Parameters for reporting usage.
+#[derive(Debug, Deserialize)]
+pub struct ReportUsageParams {
+    /// Merchant base URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// Metric identifier.
+    pub metric_id: String,
+    /// Usage quantity.
+    pub quantity: u64,
+    /// Idempotency key.
+    pub idempotency_key: Option<String>,
+    /// Action (set or increment).
+    pub action: Option<UsageAction>,
+    /// Consumer country code (ACRO contextual data).
+    pub country_code: String,
+    /// Consumer postal/ZIP code (ACRO contextual data).
+    pub zip: String,
+    /// Consumer IP address (ACRO contextual data).
+    pub ip_address: String,
+    /// Consumer user agent (ACRO contextual data).
+    pub user_agent: String,
+    /// Consumer platform (ACRO contextual data).
+    pub platform: String,
+}
+
+/// Parameters for getting usage summary.
+#[derive(Debug, Deserialize)]
+pub struct GetUsageParams {
+    /// Merchant base URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// Consumer country code (ACRO contextual data).
+    pub country_code: String,
+    /// Consumer postal/ZIP code (ACRO contextual data).
+    pub zip: String,
+    /// Consumer IP address (ACRO contextual data).
+    pub ip_address: String,
+    /// Consumer user agent (ACRO contextual data).
+    pub user_agent: String,
+    /// Consumer platform (ACRO contextual data).
+    pub platform: String,
+}
+
+/// Parameters for updating payment method.
+#[derive(Debug, Deserialize)]
+pub struct UpdatePaymentMethodParams {
+    /// Merchant base URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// New payment method (encrypted via APC).
+    pub payment_method: crate::mcp::payment::PaymentMethodParams,
+    /// Merchant RSA public key for APC.
+    pub merchant_public_key_pem: String,
+    /// Consumer country code (ACRO contextual data).
+    pub country_code: String,
+    /// Consumer postal/ZIP code (ACRO contextual data).
+    pub zip: String,
+    /// Consumer IP address (ACRO contextual data).
+    pub ip_address: String,
+    /// Consumer user agent (ACRO contextual data).
+    pub user_agent: String,
+    /// Consumer platform (ACRO contextual data).
+    pub platform: String,
+}
+
+/// Parameters for previewing proration.
+#[derive(Debug, Deserialize)]
+pub struct PreviewProrationParams {
+    /// Merchant base URL.
+    pub merchant_url: String,
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Subscription identifier.
+    pub subscription_id: String,
+    /// Target plan ID (for plan change).
+    pub target_plan_id: Option<String>,
+    /// Target quantity (for quantity change).
+    pub target_quantity: Option<u32>,
+    /// Consumer country code (ACRO contextual data).
+    pub country_code: String,
+    /// Consumer postal/ZIP code (ACRO contextual data).
+    pub zip: String,
+    /// Consumer IP address (ACRO contextual data).
+    pub ip_address: String,
+    /// Consumer user agent (ACRO contextual data).
+    pub user_agent: String,
+    /// Consumer platform (ACRO contextual data).
+    pub platform: String,
+}
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+/// Proration preview response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProrationPreview {
+    /// Credit for unused time on current plan.
+    pub credit_amount: Decimal,
+    /// Charge for new plan prorated.
+    pub charge_amount: Decimal,
+    /// Net amount (charge - credit).
+    pub net_amount: Decimal,
+    /// When proration would apply.
+    pub effective_date: DateTime<Utc>,
+    /// Currency code.
+    pub currency: String,
+    /// Line items breakdown.
+    pub line_items: Vec<ProrationLineItem>,
+}
+
+/// Single line item in proration preview.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProrationLineItem {
+    /// Item description.
+    pub description: String,
+    /// Item amount.
+    pub amount: Decimal,
+    /// Item quantity.
+    pub quantity: Option<u32>,
+    /// Period start.
+    pub period_start: DateTime<Utc>,
+    /// Period end.
+    pub period_end: DateTime<Utc>,
+}
+
+// ============================================================================
+// Tool Implementations
+// ============================================================================
+
+/// Retrieves available subscription plans from merchant.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url))]
+pub async fn get_subscription_plans(
+    signer: &TapSigner,
+    params: GetPlansParams,
+) -> Result<PlanCatalog> {
+    info!("fetching subscription plans");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let mut query_params = vec![("consumer_id", params.consumer_id.clone())];
+    if let Some(ref cycle) = params.billing_cycle {
+        query_params.push(("billing_cycle", cycle.clone()));
+    }
+    if let Some(ref pricing) = params.pricing_type {
+        query_params.push(("pricing_type", pricing.clone()));
+    }
+    if params.include_inactive.unwrap_or(false) {
+        query_params.push(("include_inactive", "true".to_owned()));
+    }
+    if let Some(page) = params.page {
+        query_params.push(("page", page.to_string()));
+    }
+    if let Some(per_page) = params.per_page {
+        query_params.push(("per_page", per_page.to_string()));
+    }
+
+    let path = build_url_with_query(
+        "/subscriptions/plans",
+        &query_params.iter().map(|(k, v)| (*k, v.as_str())).collect::<Vec<_>>(),
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Get,
+        &path,
+        InteractionType::Browse,
+        contextual_data,
+        None::<&()>,
+    )
+    .await?;
+
+    let catalog: PlanCatalog = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse plan catalog: {e}"))
+    })?;
+
+    Ok(catalog)
+}
+
+/// Retrieves a single subscription plan.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, plan_id = %params.plan_id))]
+pub async fn get_subscription_plan(
+    signer: &TapSigner,
+    params: GetPlanParams,
+) -> Result<SubscriptionPlan> {
+    info!("fetching subscription plan");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let path = build_url_with_query(&format!("/subscriptions/plans/{}", params.plan_id), &[(
+        "consumer_id",
+        &params.consumer_id,
+    )])?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Get,
+        &path,
+        InteractionType::Browse,
+        contextual_data,
+        None::<&()>,
+    )
+    .await?;
+
+    let plan: SubscriptionPlan = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse plan: {e}"))
+    })?;
+
+    Ok(plan)
+}
+
+/// Request body for creating a subscription.
+#[derive(Debug, Serialize)]
+struct CreateSubscriptionRequest {
+    plan_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quantity: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_trial: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    billing_address: Option<Address>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    apc: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    promo_code: Option<String>,
+}
+
+/// Creates a new subscription.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, plan_id = %params.plan_id))]
+pub async fn create_subscription(
+    signer: &TapSigner,
+    params: CreateSubscriptionParams,
+) -> Result<SubscriptionResponse> {
+    info!("creating subscription");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let apc = if let (Some(payment_method), Some(merchant_key_pem)) =
+        (params.payment_method, params.merchant_public_key_pem)
+    {
+        let merchant_public_key =
+            crate::tap::apc::RsaPublicKey::from_pem(merchant_key_pem.as_bytes())?;
+        let payment_method = payment_method.into();
+        let nonce = uuid::Uuid::new_v4().to_string();
+        let apc_jwe = signer.generate_apc(&nonce, &payment_method, &merchant_public_key)?;
+        Some(serde_json::to_string(&apc_jwe).map_err(|e| {
+            crate::error::BridgeError::CryptoError(format!("APC serialization failed: {e}"))
+        })?)
+    } else {
+        None
+    };
+
+    let request_body = CreateSubscriptionRequest {
+        plan_id: params.plan_id,
+        quantity: params.quantity,
+        start_trial: params.start_trial,
+        billing_address: params.billing_address,
+        apc,
+        promo_code: params.promo_code,
+    };
+
+    let path = build_url_with_query("/subscriptions", &[("consumer_id", &params.consumer_id)])?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Post,
+        &path,
+        InteractionType::Checkout,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let subscription: SubscriptionResponse = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse subscription: {e}"))
+    })?;
+
+    Ok(subscription)
+}
+
+/// Retrieves subscription details.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn get_subscription(
+    signer: &TapSigner,
+    params: GetSubscriptionParams,
+) -> Result<SubscriptionResponse> {
+    info!("fetching subscription");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let path = build_url_with_query(&format!("/subscriptions/{}", params.subscription_id), &[(
+        "consumer_id",
+        &params.consumer_id,
+    )])?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Get,
+        &path,
+        InteractionType::Browse,
+        contextual_data,
+        None::<&()>,
+    )
+    .await?;
+
+    let subscription: SubscriptionResponse = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse subscription: {e}"))
+    })?;
+
+    Ok(subscription)
+}
+
+/// Request body for updating a subscription.
+#[derive(Debug, Serialize)]
+struct UpdateSubscriptionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quantity: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    plan_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    proration_behavior: Option<ProrationBehavior>,
+}
+
+/// Updates subscription (quantity, plan change).
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn update_subscription(
+    signer: &TapSigner,
+    params: UpdateSubscriptionParams,
+) -> Result<SubscriptionResponse> {
+    info!("updating subscription");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let request_body = UpdateSubscriptionRequest {
+        quantity: params.quantity,
+        plan_id: params.plan_id,
+        proration_behavior: params.proration_behavior,
+    };
+
+    let path = build_url_with_query(&format!("/subscriptions/{}", params.subscription_id), &[(
+        "consumer_id",
+        &params.consumer_id,
+    )])?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Put,
+        &path,
+        InteractionType::Checkout,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let subscription: SubscriptionResponse = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse subscription: {e}"))
+    })?;
+
+    Ok(subscription)
+}
+
+/// Request body for canceling a subscription.
+#[derive(Debug, Serialize)]
+struct CancelSubscriptionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cancel_at_period_end: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    request_refund: Option<bool>,
+}
+
+/// Cancels a subscription.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn cancel_subscription(
+    signer: &TapSigner,
+    params: CancelSubscriptionParams,
+) -> Result<SubscriptionResponse> {
+    info!("canceling subscription");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let request_body = CancelSubscriptionRequest {
+        cancel_at_period_end: params.cancel_at_period_end,
+        reason: params.reason,
+        request_refund: params.request_refund,
+    };
+
+    let path = build_url_with_query(
+        &format!("/subscriptions/{}/cancel", params.subscription_id),
+        &[("consumer_id", &params.consumer_id)],
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Post,
+        &path,
+        InteractionType::Checkout,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let subscription: SubscriptionResponse = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse subscription: {e}"))
+    })?;
+
+    Ok(subscription)
+}
+
+/// Request body for pausing a subscription.
+#[derive(Debug, Serialize)]
+struct PauseSubscriptionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resume_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+/// Pauses a subscription.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn pause_subscription(
+    signer: &TapSigner,
+    params: PauseSubscriptionParams,
+) -> Result<SubscriptionResponse> {
+    info!("pausing subscription");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let request_body =
+        PauseSubscriptionRequest { resume_at: params.resume_at, reason: params.reason };
+
+    let path = build_url_with_query(
+        &format!("/subscriptions/{}/pause", params.subscription_id),
+        &[("consumer_id", &params.consumer_id)],
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Post,
+        &path,
+        InteractionType::Checkout,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let subscription: SubscriptionResponse = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse subscription: {e}"))
+    })?;
+
+    Ok(subscription)
+}
+
+/// Request body for resuming a subscription.
+#[derive(Debug, Serialize)]
+struct ResumeSubscriptionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    charge_immediately: Option<bool>,
+}
+
+/// Resumes a paused subscription.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn resume_subscription(
+    signer: &TapSigner,
+    params: ResumeSubscriptionParams,
+) -> Result<SubscriptionResponse> {
+    info!("resuming subscription");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let request_body = ResumeSubscriptionRequest { charge_immediately: params.charge_immediately };
+
+    let path = build_url_with_query(
+        &format!("/subscriptions/{}/resume", params.subscription_id),
+        &[("consumer_id", &params.consumer_id)],
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Post,
+        &path,
+        InteractionType::Checkout,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let subscription: SubscriptionResponse = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse subscription: {e}"))
+    })?;
+
+    Ok(subscription)
+}
+
+/// Request body for reporting usage.
+#[derive(Debug, Serialize)]
+struct ReportUsageRequest {
+    metric_id: String,
+    quantity: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    idempotency_key: Option<String>,
+    action: UsageAction,
+}
+
+/// Reports usage for usage-based subscription.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id, metric_id = %params.metric_id))]
+pub async fn report_usage(signer: &TapSigner, params: ReportUsageParams) -> Result<UsageRecord> {
+    info!("reporting usage");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let request_body = ReportUsageRequest {
+        metric_id: params.metric_id,
+        quantity: params.quantity,
+        idempotency_key: params.idempotency_key,
+        action: params.action.unwrap_or(UsageAction::Increment),
+    };
+
+    let path = build_url_with_query(
+        &format!("/subscriptions/{}/usage", params.subscription_id),
+        &[("consumer_id", &params.consumer_id)],
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Post,
+        &path,
+        InteractionType::Browse,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let usage_record: UsageRecord = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse usage record: {e}"))
+    })?;
+
+    Ok(usage_record)
+}
+
+/// Gets current usage summary.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn get_usage(signer: &TapSigner, params: GetUsageParams) -> Result<UsageSummary> {
+    info!("fetching usage summary");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let path = build_url_with_query(
+        &format!("/subscriptions/{}/usage/summary", params.subscription_id),
+        &[("consumer_id", &params.consumer_id)],
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Get,
+        &path,
+        InteractionType::Browse,
+        contextual_data,
+        None::<&()>,
+    )
+    .await?;
+
+    let usage_summary: UsageSummary = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse usage summary: {e}"))
+    })?;
+
+    Ok(usage_summary)
+}
+
+/// Request body for updating payment method.
+#[derive(Debug, Serialize)]
+struct UpdatePaymentMethodRequest {
+    apc: String,
+}
+
+/// Updates payment method for subscription.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn update_payment_method(
+    signer: &TapSigner,
+    params: UpdatePaymentMethodParams,
+) -> Result<SubscriptionResponse> {
+    info!("updating payment method");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let merchant_public_key =
+        crate::tap::apc::RsaPublicKey::from_pem(params.merchant_public_key_pem.as_bytes())?;
+    let payment_method = params.payment_method.into();
+    let nonce = uuid::Uuid::new_v4().to_string();
+    let apc_jwe = signer.generate_apc(&nonce, &payment_method, &merchant_public_key)?;
+    let apc_json = serde_json::to_string(&apc_jwe).map_err(|e| {
+        crate::error::BridgeError::CryptoError(format!("APC serialization failed: {e}"))
+    })?;
+
+    let request_body = UpdatePaymentMethodRequest { apc: apc_json };
+
+    let path = build_url_with_query(
+        &format!("/subscriptions/{}/payment-method", params.subscription_id),
+        &[("consumer_id", &params.consumer_id)],
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Put,
+        &path,
+        InteractionType::Checkout,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let subscription: SubscriptionResponse = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse subscription: {e}"))
+    })?;
+
+    Ok(subscription)
+}
+
+/// Request body for proration preview.
+#[derive(Debug, Serialize)]
+struct PreviewProrationRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_plan_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_quantity: Option<u32>,
+}
+
+/// Previews proration for a planned change.
+///
+/// # Errors
+///
+/// Returns error if signature generation, HTTP request, or response parsing fails.
+#[instrument(skip(signer, params), fields(merchant_url = %params.merchant_url, subscription_id = %params.subscription_id))]
+pub async fn preview_proration(
+    signer: &TapSigner,
+    params: PreviewProrationParams,
+) -> Result<ProrationPreview> {
+    info!("previewing proration");
+
+    let contextual_data = ContextualData {
+        country_code: params.country_code,
+        zip: params.zip,
+        ip_address: params.ip_address,
+        device_data: crate::tap::acro::DeviceData {
+            user_agent: params.user_agent,
+            platform: params.platform,
+        },
+    };
+
+    let request_body = PreviewProrationRequest {
+        target_plan_id: params.target_plan_id,
+        target_quantity: params.target_quantity,
+    };
+
+    let path = build_url_with_query(
+        &format!("/subscriptions/{}/proration-preview", params.subscription_id),
+        &[("consumer_id", &params.consumer_id)],
+    )?;
+
+    let client = &*SUBSCRIPTION_HTTP_CLIENT;
+    let response = execute_tap_request_with_acro(
+        client,
+        signer,
+        &params.merchant_url,
+        &params.consumer_id,
+        HttpMethod::Post,
+        &path,
+        InteractionType::Browse,
+        contextual_data,
+        Some(&request_body),
+    )
+    .await?;
+
+    let proration_preview: ProrationPreview = serde_json::from_slice(&response).map_err(|e| {
+        crate::error::BridgeError::MerchantError(format!("failed to parse proration preview: {e}"))
+    })?;
+
+    Ok(proration_preview)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // ProrationBehavior Serialization Tests
+    // ========================================================================
+
+    #[test]
+    fn test_proration_behavior_create_prorations_serialization() {
+        let behavior = ProrationBehavior::CreateProrations;
+        let json = serde_json::to_string(&behavior).unwrap();
+        assert_eq!(json, "\"create_prorations\"");
+
+        let deserialized: ProrationBehavior = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, ProrationBehavior::CreateProrations);
+    }
+
+    #[test]
+    fn test_proration_behavior_none_serialization() {
+        let behavior = ProrationBehavior::None;
+        let json = serde_json::to_string(&behavior).unwrap();
+        assert_eq!(json, "\"none\"");
+
+        let deserialized: ProrationBehavior = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, ProrationBehavior::None);
+    }
+
+    #[test]
+    fn test_proration_behavior_always_invoice_serialization() {
+        let behavior = ProrationBehavior::AlwaysInvoice;
+        let json = serde_json::to_string(&behavior).unwrap();
+        assert_eq!(json, "\"always_invoice\"");
+
+        let deserialized: ProrationBehavior = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, ProrationBehavior::AlwaysInvoice);
+    }
+
+    #[test]
+    fn test_proration_behavior_all_variants() {
+        let variants = vec![
+            ProrationBehavior::CreateProrations,
+            ProrationBehavior::None,
+            ProrationBehavior::AlwaysInvoice,
+        ];
+
+        for variant in variants {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: ProrationBehavior = serde_json::from_str(&json).unwrap();
+            assert_eq!(deserialized, variant);
+        }
+    }
+}

--- a/tap-mcp-bridge/src/merchant/config.rs
+++ b/tap-mcp-bridge/src/merchant/config.rs
@@ -197,7 +197,7 @@ impl EndpointConfig {
 }
 
 /// Validates an endpoint path template for security issues.
-fn validate_endpoint_path(name: &str, path: &str) -> Result<()> {
+pub(crate) fn validate_endpoint_path(name: &str, path: &str) -> Result<()> {
     // Check for path traversal
     if path.contains("..") {
         return Err(BridgeError::MerchantConfigError(format!(
@@ -279,7 +279,7 @@ impl FieldMappingConfig {
 }
 
 /// Validates a field name for security issues.
-fn validate_field_name(context: &str, name: &str) -> Result<()> {
+pub(crate) fn validate_field_name(context: &str, name: &str) -> Result<()> {
     // Check for forbidden names (prototype pollution)
     if FORBIDDEN_FIELD_NAMES.contains(&name) {
         return Err(BridgeError::MerchantConfigError(format!(

--- a/tap-mcp-bridge/src/merchant/mod.rs
+++ b/tap-mcp-bridge/src/merchant/mod.rs
@@ -7,6 +7,8 @@ pub mod config;
 pub mod default;
 pub mod endpoint;
 pub mod field_map;
+pub mod subscription_config;
+pub mod subscription_traits;
 pub mod traits;
 pub mod transform;
 
@@ -14,6 +16,14 @@ pub use config::{AuthConfig, EndpointConfig, FieldMappingConfig, MerchantConfig,
 pub use default::DefaultMerchant;
 pub use endpoint::{ConfigurableEndpointResolver, DefaultEndpointResolver};
 pub use field_map::{ConfigurableFieldMapper, IdentityFieldMapper};
+pub use subscription_config::{
+    SubscriptionEndpointConfig, SubscriptionFieldMappingConfig, SubscriptionMerchantConfig,
+    SubscriptionSettings,
+};
+pub use subscription_traits::{
+    DefaultSubscriptionEndpointResolver, DefaultSubscriptionMerchant, PlanQueryParams,
+    SubscriptionEndpointResolver, SubscriptionMerchantApi,
+};
 pub use traits::{
     EndpointResolver, FieldMapper, MerchantApi, RequestTransformer, ResponseTransformer,
 };

--- a/tap-mcp-bridge/src/merchant/subscription_config.rs
+++ b/tap-mcp-bridge/src/merchant/subscription_config.rs
@@ -1,0 +1,494 @@
+//! Subscription configuration types.
+//!
+//! TOML-deserializable configuration for subscription endpoints and field mappings.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::{
+    error::Result,
+    merchant::config::{validate_endpoint_path, validate_field_name},
+};
+
+/// Subscription endpoint configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SubscriptionEndpointConfig {
+    /// Plans list endpoint (default: "/subscriptions/plans").
+    pub plans: Option<String>,
+
+    /// Single plan endpoint template (default: "/subscriptions/plans/{id}").
+    pub plan: Option<String>,
+
+    /// Subscriptions list endpoint (default: "/subscriptions").
+    pub subscriptions: Option<String>,
+
+    /// Single subscription endpoint template (default: "/subscriptions/{id}").
+    pub subscription: Option<String>,
+
+    /// Cancel subscription endpoint (default: "/subscriptions/{id}/cancel").
+    pub cancel: Option<String>,
+
+    /// Pause subscription endpoint (default: "/subscriptions/{id}/pause").
+    pub pause: Option<String>,
+
+    /// Resume subscription endpoint (default: "/subscriptions/{id}/resume").
+    pub resume: Option<String>,
+
+    /// Report usage endpoint (default: "/subscriptions/{id}/usage").
+    pub usage: Option<String>,
+
+    /// Usage summary endpoint (default: "/subscriptions/{id}/usage/summary").
+    pub usage_summary: Option<String>,
+
+    /// Payment method update endpoint (default: "/subscriptions/{id}/payment-method").
+    pub payment_method: Option<String>,
+
+    /// Proration preview endpoint (default: "/subscriptions/{id}/proration-preview").
+    pub proration_preview: Option<String>,
+}
+
+impl SubscriptionEndpointConfig {
+    /// Validates endpoint templates for security issues.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if any endpoint contains invalid patterns.
+    pub fn validate(&self) -> Result<()> {
+        let endpoints = [
+            ("plans", &self.plans),
+            ("plan", &self.plan),
+            ("subscriptions", &self.subscriptions),
+            ("subscription", &self.subscription),
+            ("cancel", &self.cancel),
+            ("pause", &self.pause),
+            ("resume", &self.resume),
+            ("usage", &self.usage),
+            ("usage_summary", &self.usage_summary),
+            ("payment_method", &self.payment_method),
+            ("proration_preview", &self.proration_preview),
+        ];
+
+        for (name, endpoint) in endpoints {
+            if let Some(path) = endpoint {
+                validate_endpoint_path(name, path)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Subscription field mapping configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SubscriptionFieldMappingConfig {
+    /// Plan field mappings.
+    #[serde(default)]
+    pub plan: HashMap<String, String>,
+
+    /// Subscription field mappings.
+    #[serde(default)]
+    pub subscription: HashMap<String, String>,
+
+    /// Usage field mappings.
+    #[serde(default)]
+    pub usage: HashMap<String, String>,
+
+    /// Proration field mappings.
+    #[serde(default)]
+    pub proration: HashMap<String, String>,
+}
+
+impl SubscriptionFieldMappingConfig {
+    /// Validates field mapping names for security issues.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if any field name is invalid.
+    pub fn validate(&self) -> Result<()> {
+        for (context, mappings) in [
+            ("plan", &self.plan),
+            ("subscription", &self.subscription),
+            ("usage", &self.usage),
+            ("proration", &self.proration),
+        ] {
+            for (key, value) in mappings {
+                validate_field_name(&format!("{context} key"), key)?;
+                validate_field_name(&format!("{context} value"), value)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Extended merchant configuration with subscription support.
+///
+/// Extends base `MerchantConfig` with subscription-specific settings.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SubscriptionMerchantConfig {
+    /// Base merchant configuration.
+    #[serde(flatten)]
+    pub base: crate::merchant::MerchantConfig,
+
+    /// Subscription endpoint configuration.
+    #[serde(default)]
+    pub subscription_endpoints: SubscriptionEndpointConfig,
+
+    /// Subscription field mappings.
+    #[serde(default)]
+    pub subscription_field_mappings: SubscriptionFieldMappingConfig,
+
+    /// Subscription-specific settings.
+    #[serde(default)]
+    pub subscription_settings: SubscriptionSettings,
+}
+
+/// Subscription-specific merchant settings.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubscriptionSettings {
+    /// Grace period for past-due subscriptions (days).
+    #[serde(default = "default_grace_period")]
+    pub grace_period_days: u32,
+
+    /// Maximum retry attempts for failed payments.
+    #[serde(default = "default_max_retries")]
+    pub max_payment_retries: u32,
+
+    /// Whether pausing is supported by this merchant.
+    #[serde(default = "default_true")]
+    pub supports_pause: bool,
+
+    /// Whether usage-based billing is supported.
+    #[serde(default = "default_true")]
+    pub supports_usage: bool,
+
+    /// Whether proration preview is available.
+    #[serde(default = "default_true")]
+    pub supports_proration_preview: bool,
+}
+
+impl Default for SubscriptionSettings {
+    fn default() -> Self {
+        Self {
+            grace_period_days: default_grace_period(),
+            max_payment_retries: default_max_retries(),
+            supports_pause: true,
+            supports_usage: true,
+            supports_proration_preview: true,
+        }
+    }
+}
+
+fn default_grace_period() -> u32 {
+    7
+}
+fn default_max_retries() -> u32 {
+    4
+}
+fn default_true() -> bool {
+    true
+}
+
+impl SubscriptionSettings {
+    /// Validates subscription settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if `grace_period_days` is outside valid range (1-365 days).
+    pub fn validate(&self) -> Result<()> {
+        if self.grace_period_days == 0 || self.grace_period_days > 365 {
+            return Err(crate::error::BridgeError::MerchantConfigError(
+                "grace_period_days must be between 1 and 365".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl SubscriptionMerchantConfig {
+    /// Validates the complete subscription configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if any configuration value is invalid.
+    pub fn validate(&self) -> Result<()> {
+        self.base.validate()?;
+        self.subscription_endpoints.validate()?;
+        self.subscription_field_mappings.validate()?;
+        self.subscription_settings.validate()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ========================================================================
+    // SubscriptionEndpointConfig Tests
+    // ========================================================================
+
+    #[test]
+    fn test_subscription_endpoint_config_default() {
+        let config = SubscriptionEndpointConfig::default();
+        assert!(config.plans.is_none());
+        assert!(config.subscription.is_none());
+        assert!(config.cancel.is_none());
+        assert!(config.pause.is_none());
+        assert!(config.usage.is_none());
+    }
+
+    #[test]
+    fn test_subscription_endpoint_config_validate_valid() {
+        let config = SubscriptionEndpointConfig {
+            plans: Some("/subscriptions/plans".to_owned()),
+            plan: Some("/subscriptions/plans/{id}".to_owned()),
+            subscriptions: Some("/subscriptions".to_owned()),
+            subscription: Some("/subscriptions/{id}".to_owned()),
+            cancel: Some("/subscriptions/{id}/cancel".to_owned()),
+            pause: Some("/subscriptions/{id}/pause".to_owned()),
+            resume: Some("/subscriptions/{id}/resume".to_owned()),
+            usage: Some("/subscriptions/{id}/usage".to_owned()),
+            usage_summary: Some("/subscriptions/{id}/usage/summary".to_owned()),
+            payment_method: Some("/subscriptions/{id}/payment-method".to_owned()),
+            proration_preview: Some("/subscriptions/{id}/proration-preview".to_owned()),
+        };
+
+        let result = config.validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_subscription_endpoint_config_validate_path_traversal() {
+        let config = SubscriptionEndpointConfig {
+            plans: Some("/../etc/passwd".to_owned()),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_subscription_endpoint_config_validate_double_slash() {
+        let config = SubscriptionEndpointConfig {
+            subscription: Some("/subscriptions//{id}".to_owned()),
+            ..Default::default()
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // SubscriptionFieldMappingConfig Tests
+    // ========================================================================
+
+    #[test]
+    fn test_subscription_field_mapping_config_default() {
+        let config = SubscriptionFieldMappingConfig::default();
+        assert!(config.plan.is_empty());
+        assert!(config.subscription.is_empty());
+        assert!(config.usage.is_empty());
+        assert!(config.proration.is_empty());
+    }
+
+    #[test]
+    fn test_subscription_field_mapping_config_validate_valid() {
+        let mut config = SubscriptionFieldMappingConfig::default();
+        config.plan.insert("plan_id".to_owned(), "id".to_owned());
+        config.subscription.insert("subscription_id".to_owned(), "sub_id".to_owned());
+
+        let result = config.validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_subscription_field_mapping_config_validate_forbidden_field_name() {
+        let mut config = SubscriptionFieldMappingConfig::default();
+        config.plan.insert("__proto__".to_owned(), "id".to_owned());
+
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_subscription_field_mapping_config_validate_null_byte() {
+        let mut config = SubscriptionFieldMappingConfig::default();
+        config.subscription.insert("sub\0id".to_owned(), "value".to_owned());
+
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // SubscriptionSettings Tests
+    // ========================================================================
+
+    #[test]
+    fn test_subscription_settings_default() {
+        let settings = SubscriptionSettings::default();
+        assert_eq!(settings.grace_period_days, 7);
+        assert_eq!(settings.max_payment_retries, 4);
+        assert!(settings.supports_pause);
+        assert!(settings.supports_usage);
+        assert!(settings.supports_proration_preview);
+    }
+
+    #[test]
+    fn test_subscription_settings_custom() {
+        let settings = SubscriptionSettings {
+            grace_period_days: 14,
+            max_payment_retries: 10,
+            supports_pause: false,
+            supports_usage: true,
+            supports_proration_preview: false,
+        };
+        assert_eq!(settings.grace_period_days, 14);
+        assert_eq!(settings.max_payment_retries, 10);
+        assert!(!settings.supports_pause);
+        assert!(settings.supports_usage);
+        assert!(!settings.supports_proration_preview);
+    }
+
+    // ========================================================================
+    // SubscriptionMerchantConfig Tests
+    // ========================================================================
+
+    #[test]
+    fn test_subscription_merchant_config_default() {
+        let config = SubscriptionMerchantConfig::default();
+        assert_eq!(config.subscription_settings.grace_period_days, 7);
+        assert!(config.subscription_endpoints.plans.is_none());
+    }
+
+    #[test]
+    fn test_subscription_merchant_config_from_toml_basic() {
+        let toml = r#"
+            name = "Test Merchant"
+            base_url = "https://api.test.com"
+
+            [subscription_endpoints]
+            plans = "/billing/plans"
+            subscription = "/subscriptions/{id}"
+
+            [subscription_settings]
+            grace_period_days = 14
+            max_payment_retries = 3
+        "#;
+
+        let config: SubscriptionMerchantConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.base.name, "Test Merchant");
+        assert_eq!(config.subscription_endpoints.plans.as_deref(), Some("/billing/plans"));
+        assert_eq!(config.subscription_settings.grace_period_days, 14);
+        assert_eq!(config.subscription_settings.max_payment_retries, 3);
+    }
+
+    #[test]
+    fn test_subscription_merchant_config_from_toml_full() {
+        let toml = r#"
+            name = "Full Test Merchant"
+            base_url = "https://api.test.com"
+
+            [subscription_endpoints]
+            plans = "/api/plans"
+            plan = "/api/plans/{id}"
+            subscriptions = "/api/subs"
+            subscription = "/api/subs/{id}"
+            cancel = "/api/subs/{id}/cancel"
+            pause = "/api/subs/{id}/pause"
+            resume = "/api/subs/{id}/resume"
+            usage = "/api/subs/{id}/usage"
+            usage_summary = "/api/subs/{id}/usage/summary"
+            payment_method = "/api/subs/{id}/payment"
+            proration_preview = "/api/subs/{id}/proration"
+
+            [subscription_field_mappings.plan]
+            plan_id = "id"
+            plan_name = "name"
+
+            [subscription_field_mappings.subscription]
+            subscription_id = "sub_id"
+
+            [subscription_settings]
+            grace_period_days = 10
+            max_payment_retries = 5
+            supports_pause = true
+            supports_usage = true
+            supports_proration_preview = true
+        "#;
+
+        let config: SubscriptionMerchantConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.base.name, "Full Test Merchant");
+        assert_eq!(config.subscription_endpoints.plans.as_deref(), Some("/api/plans"));
+        assert_eq!(config.subscription_endpoints.cancel.as_deref(), Some("/api/subs/{id}/cancel"));
+        assert_eq!(config.subscription_field_mappings.plan.get("plan_id"), Some(&"id".to_owned()));
+        assert_eq!(config.subscription_settings.grace_period_days, 10);
+        assert_eq!(config.subscription_settings.max_payment_retries, 5);
+    }
+
+    #[test]
+    fn test_subscription_merchant_config_validate_success() {
+        let toml = r#"
+            name = "Valid Merchant"
+            base_url = "https://api.valid.com"
+
+            [subscription_endpoints]
+            plans = "/subscriptions/plans"
+
+            [subscription_settings]
+            grace_period_days = 7
+        "#;
+
+        let config: SubscriptionMerchantConfig = toml::from_str(toml).unwrap();
+        let result = config.validate();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_subscription_merchant_config_validate_invalid_endpoint() {
+        let toml = r#"
+            name = "Invalid Merchant"
+            base_url = "https://api.invalid.com"
+
+            [subscription_endpoints]
+            plans = "/../etc/passwd"
+        "#;
+
+        let config: SubscriptionMerchantConfig = toml::from_str(toml).unwrap();
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_subscription_merchant_config_validate_invalid_field_mapping() {
+        let toml = r#"
+            name = "Invalid Mapping"
+            base_url = "https://api.test.com"
+
+            [subscription_field_mappings.plan]
+            __proto__ = "id"
+        "#;
+
+        let config: SubscriptionMerchantConfig = toml::from_str(toml).unwrap();
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_subscription_merchant_config_default_values() {
+        let toml = r#"
+            name = "Minimal Merchant"
+            base_url = "https://api.minimal.com"
+        "#;
+
+        let config: SubscriptionMerchantConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.subscription_settings.grace_period_days, 7);
+        assert_eq!(config.subscription_settings.max_payment_retries, 4);
+        assert!(config.subscription_settings.supports_pause);
+        assert!(config.subscription_settings.supports_usage);
+        assert!(config.subscription_settings.supports_proration_preview);
+        assert!(config.subscription_endpoints.plans.is_none());
+        assert!(config.subscription_field_mappings.plan.is_empty());
+    }
+}

--- a/tap-mcp-bridge/src/merchant/subscription_traits.rs
+++ b/tap-mcp-bridge/src/merchant/subscription_traits.rs
@@ -1,0 +1,535 @@
+//! Subscription merchant API traits.
+//!
+//! Extends `MerchantApi` with subscription-specific operations.
+
+use serde::de::DeserializeOwned;
+
+use crate::{
+    error::Result,
+    mcp::subscriptions::{
+        lifecycle::SubscriptionResponse,
+        models::{PlanCatalog, SubscriptionPlan, UsageSummary},
+        tools::ProrationPreview,
+    },
+    merchant::traits::MerchantApi,
+};
+
+/// URL-encode a string for use in query parameters.
+fn url_encode(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' {
+                c.to_string()
+            } else {
+                format!("%{:02X}", c as u8)
+            }
+        })
+        .collect()
+}
+
+/// Extension of `MerchantApi` for subscription operations.
+///
+/// This trait extends the base `MerchantApi` with subscription-specific
+/// type mappings and conversions. Implementors can map merchant-specific
+/// subscription response formats to the standard types.
+///
+/// # Sealed Trait Pattern
+///
+/// This trait uses the sealed pattern to prevent external implementations
+/// while allowing the library to evolve the API without breaking changes.
+pub trait SubscriptionMerchantApi: MerchantApi + private::Sealed {
+    /// Subscription plan catalog response type.
+    type PlanCatalog: DeserializeOwned + Send;
+
+    /// Single subscription plan response type.
+    type Plan: DeserializeOwned + Send;
+
+    /// Subscription response type.
+    type Subscription: DeserializeOwned + Send;
+
+    /// Usage summary response type.
+    type UsageSummary: DeserializeOwned + Send;
+
+    /// Proration preview response type.
+    type ProrationPreview: DeserializeOwned + Send;
+
+    /// Returns the subscription endpoint resolver.
+    fn subscription_endpoints(&self) -> &dyn SubscriptionEndpointResolver;
+
+    /// Converts merchant plan catalog to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails.
+    fn to_standard_plan_catalog(&self, catalog: Self::PlanCatalog) -> Result<PlanCatalog>;
+
+    /// Converts merchant plan to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails.
+    fn to_standard_plan(&self, plan: Self::Plan) -> Result<SubscriptionPlan>;
+
+    /// Converts merchant subscription to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails.
+    fn to_standard_subscription(&self, sub: Self::Subscription) -> Result<SubscriptionResponse>;
+
+    /// Converts merchant usage summary to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails.
+    fn to_standard_usage(&self, usage: Self::UsageSummary) -> Result<UsageSummary>;
+
+    /// Converts merchant proration preview to standard format.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if conversion fails.
+    fn to_standard_proration(&self, preview: Self::ProrationPreview) -> Result<ProrationPreview>;
+}
+
+/// Resolves subscription-specific API endpoints.
+pub trait SubscriptionEndpointResolver: Send + Sync {
+    /// Subscription plans list endpoint.
+    fn plans_endpoint(&self, params: &PlanQueryParams) -> String;
+
+    /// Single plan endpoint.
+    fn plan_endpoint(&self, plan_id: &str) -> String;
+
+    /// Subscriptions list endpoint.
+    fn subscriptions_endpoint(&self) -> String;
+
+    /// Single subscription endpoint.
+    fn subscription_endpoint(&self, subscription_id: &str) -> String;
+
+    /// Subscription cancel endpoint.
+    fn cancel_endpoint(&self, subscription_id: &str) -> String;
+
+    /// Subscription pause endpoint.
+    fn pause_endpoint(&self, subscription_id: &str) -> String;
+
+    /// Subscription resume endpoint.
+    fn resume_endpoint(&self, subscription_id: &str) -> String;
+
+    /// Usage reporting endpoint.
+    fn usage_endpoint(&self, subscription_id: &str) -> String;
+
+    /// Usage summary endpoint.
+    fn usage_summary_endpoint(&self, subscription_id: &str) -> String;
+
+    /// Payment method update endpoint.
+    fn payment_method_endpoint(&self, subscription_id: &str) -> String;
+
+    /// Proration preview endpoint.
+    fn proration_preview_endpoint(&self, subscription_id: &str) -> String;
+}
+
+/// Query parameters for plan listing.
+#[derive(Debug, Clone, Default)]
+pub struct PlanQueryParams {
+    /// Consumer identifier.
+    pub consumer_id: String,
+    /// Filter by billing cycle type.
+    pub billing_cycle: Option<String>,
+    /// Filter by pricing model type.
+    pub pricing_type: Option<String>,
+    /// Include inactive plans.
+    pub include_inactive: bool,
+    /// Page number.
+    pub page: Option<u32>,
+    /// Items per page.
+    pub per_page: Option<u32>,
+}
+
+// Sealed trait pattern to prevent external implementations
+mod private {
+    pub trait Sealed {}
+}
+
+/// Default implementation for standard TAP subscription merchants.
+#[derive(Debug)]
+pub struct DefaultSubscriptionMerchant {
+    base: crate::merchant::DefaultMerchant,
+}
+
+impl private::Sealed for DefaultSubscriptionMerchant {}
+
+impl DefaultSubscriptionMerchant {
+    /// Creates a new default subscription merchant.
+    #[must_use]
+    pub fn new(base: crate::merchant::DefaultMerchant) -> Self {
+        Self { base }
+    }
+}
+
+impl MerchantApi for DefaultSubscriptionMerchant {
+    type CartState = crate::mcp::models::CartState;
+    type Order = crate::mcp::models::Order;
+    type PaymentResult = crate::mcp::models::PaymentResult;
+    type Product = crate::mcp::models::Product;
+    type ProductCatalog = crate::mcp::models::ProductCatalog;
+
+    fn endpoint_resolver(&self) -> &dyn crate::merchant::EndpointResolver {
+        self.base.endpoint_resolver()
+    }
+
+    fn field_mapper(&self) -> &dyn crate::merchant::FieldMapper {
+        self.base.field_mapper()
+    }
+
+    fn to_standard_catalog(
+        &self,
+        catalog: Self::ProductCatalog,
+    ) -> Result<crate::mcp::models::ProductCatalog> {
+        Ok(catalog)
+    }
+
+    fn to_standard_product(&self, product: Self::Product) -> Result<crate::mcp::models::Product> {
+        Ok(product)
+    }
+
+    fn to_standard_cart(&self, cart: Self::CartState) -> Result<crate::mcp::models::CartState> {
+        Ok(cart)
+    }
+
+    fn to_standard_order(&self, order: Self::Order) -> Result<crate::mcp::models::Order> {
+        Ok(order)
+    }
+
+    fn to_standard_payment(
+        &self,
+        result: Self::PaymentResult,
+    ) -> Result<crate::mcp::models::PaymentResult> {
+        Ok(result)
+    }
+}
+
+/// Default subscription endpoint resolver.
+#[derive(Debug)]
+pub struct DefaultSubscriptionEndpointResolver;
+
+impl SubscriptionEndpointResolver for DefaultSubscriptionEndpointResolver {
+    fn plans_endpoint(&self, params: &PlanQueryParams) -> String {
+        use std::fmt::Write;
+
+        let mut url = String::from("/subscriptions/plans?");
+        url.push_str("consumer_id=");
+        url.push_str(&url_encode(&params.consumer_id));
+        if let Some(ref cycle) = params.billing_cycle {
+            url.push_str("&billing_cycle=");
+            url.push_str(&url_encode(cycle));
+        }
+        if let Some(ref pricing) = params.pricing_type {
+            url.push_str("&pricing_type=");
+            url.push_str(&url_encode(pricing));
+        }
+        if params.include_inactive {
+            url.push_str("&include_inactive=true");
+        }
+        if let Some(page) = params.page {
+            write!(url, "&page={page}").expect("write to String cannot fail");
+        }
+        if let Some(per_page) = params.per_page {
+            write!(url, "&per_page={per_page}").expect("write to String cannot fail");
+        }
+        url
+    }
+
+    fn plan_endpoint(&self, plan_id: &str) -> String {
+        format!("/subscriptions/plans/{plan_id}")
+    }
+
+    fn subscriptions_endpoint(&self) -> String {
+        "/subscriptions".to_owned()
+    }
+
+    fn subscription_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}")
+    }
+
+    fn cancel_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}/cancel")
+    }
+
+    fn pause_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}/pause")
+    }
+
+    fn resume_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}/resume")
+    }
+
+    fn usage_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}/usage")
+    }
+
+    fn usage_summary_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}/usage/summary")
+    }
+
+    fn payment_method_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}/payment-method")
+    }
+
+    fn proration_preview_endpoint(&self, subscription_id: &str) -> String {
+        format!("/subscriptions/{subscription_id}/proration-preview")
+    }
+}
+
+impl SubscriptionMerchantApi for DefaultSubscriptionMerchant {
+    type Plan = SubscriptionPlan;
+    type PlanCatalog = PlanCatalog;
+    type ProrationPreview = ProrationPreview;
+    type Subscription = SubscriptionResponse;
+    type UsageSummary = UsageSummary;
+
+    fn subscription_endpoints(&self) -> &dyn SubscriptionEndpointResolver {
+        &DefaultSubscriptionEndpointResolver
+    }
+
+    fn to_standard_plan_catalog(&self, catalog: Self::PlanCatalog) -> Result<PlanCatalog> {
+        Ok(catalog)
+    }
+
+    fn to_standard_plan(&self, plan: Self::Plan) -> Result<SubscriptionPlan> {
+        Ok(plan)
+    }
+
+    fn to_standard_subscription(&self, sub: Self::Subscription) -> Result<SubscriptionResponse> {
+        Ok(sub)
+    }
+
+    fn to_standard_usage(&self, usage: Self::UsageSummary) -> Result<UsageSummary> {
+        Ok(usage)
+    }
+
+    fn to_standard_proration(&self, preview: Self::ProrationPreview) -> Result<ProrationPreview> {
+        Ok(preview)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merchant::DefaultMerchant;
+
+    // ========================================================================
+    // PlanQueryParams Tests
+    // ========================================================================
+
+    #[test]
+    fn test_plan_query_params_default() {
+        let params = PlanQueryParams::default();
+        assert!(params.consumer_id.is_empty());
+        assert!(params.billing_cycle.is_none());
+        assert!(params.pricing_type.is_none());
+        assert!(!params.include_inactive);
+        assert!(params.page.is_none());
+        assert!(params.per_page.is_none());
+    }
+
+    #[test]
+    fn test_plan_query_params_custom() {
+        let params = PlanQueryParams {
+            consumer_id: "consumer-123".to_owned(),
+            billing_cycle: Some("monthly".to_owned()),
+            pricing_type: Some("flat_rate".to_owned()),
+            include_inactive: true,
+            page: Some(2),
+            per_page: Some(50),
+        };
+        assert_eq!(params.consumer_id, "consumer-123");
+        assert_eq!(params.billing_cycle.as_deref(), Some("monthly"));
+        assert_eq!(params.pricing_type.as_deref(), Some("flat_rate"));
+        assert!(params.include_inactive);
+        assert_eq!(params.page, Some(2));
+        assert_eq!(params.per_page, Some(50));
+    }
+
+    // ========================================================================
+    // DefaultSubscriptionEndpointResolver Tests
+    // ========================================================================
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_plans() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let params = PlanQueryParams {
+            consumer_id: "consumer-456".to_owned(),
+            billing_cycle: None,
+            pricing_type: None,
+            include_inactive: false,
+            page: None,
+            per_page: None,
+        };
+
+        let endpoint = resolver.plans_endpoint(&params);
+        assert!(endpoint.starts_with("/subscriptions/plans?"));
+        assert!(endpoint.contains("consumer_id=consumer-456"));
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_plans_with_filters() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let params = PlanQueryParams {
+            consumer_id: "consumer-789".to_owned(),
+            billing_cycle: Some("monthly".to_owned()),
+            pricing_type: Some("tiered".to_owned()),
+            include_inactive: true,
+            page: Some(2),
+            per_page: Some(25),
+        };
+
+        let endpoint = resolver.plans_endpoint(&params);
+        assert!(endpoint.contains("consumer_id=consumer-789"));
+        assert!(endpoint.contains("&billing_cycle=monthly"));
+        assert!(endpoint.contains("&pricing_type=tiered"));
+        assert!(endpoint.contains("&include_inactive=true"));
+        assert!(endpoint.contains("&page=2"));
+        assert!(endpoint.contains("&per_page=25"));
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_plan() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.plan_endpoint("plan-basic");
+        assert_eq!(endpoint, "/subscriptions/plans/plan-basic");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_subscriptions() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.subscriptions_endpoint();
+        assert_eq!(endpoint, "/subscriptions");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_subscription() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.subscription_endpoint("sub-123");
+        assert_eq!(endpoint, "/subscriptions/sub-123");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_cancel() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.cancel_endpoint("sub-456");
+        assert_eq!(endpoint, "/subscriptions/sub-456/cancel");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_pause() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.pause_endpoint("sub-789");
+        assert_eq!(endpoint, "/subscriptions/sub-789/pause");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_resume() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.resume_endpoint("sub-101");
+        assert_eq!(endpoint, "/subscriptions/sub-101/resume");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_usage() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.usage_endpoint("sub-202");
+        assert_eq!(endpoint, "/subscriptions/sub-202/usage");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_usage_summary() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.usage_summary_endpoint("sub-303");
+        assert_eq!(endpoint, "/subscriptions/sub-303/usage/summary");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_payment_method() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.payment_method_endpoint("sub-404");
+        assert_eq!(endpoint, "/subscriptions/sub-404/payment-method");
+    }
+
+    #[test]
+    fn test_default_subscription_endpoint_resolver_proration_preview() {
+        let resolver = DefaultSubscriptionEndpointResolver;
+        let endpoint = resolver.proration_preview_endpoint("sub-505");
+        assert_eq!(endpoint, "/subscriptions/sub-505/proration-preview");
+    }
+
+    // ========================================================================
+    // DefaultSubscriptionMerchant Tests
+    // ========================================================================
+
+    #[test]
+    fn test_default_subscription_merchant_creation() {
+        let base = DefaultMerchant::new();
+        let merchant = DefaultSubscriptionMerchant::new(base);
+
+        let resolver = merchant.subscription_endpoints();
+        assert_eq!(resolver.subscriptions_endpoint(), "/subscriptions");
+    }
+
+    #[test]
+    fn test_default_subscription_merchant_plan_catalog_passthrough() {
+        use crate::mcp::subscriptions::models::PlanCatalog;
+
+        let base = DefaultMerchant::new();
+        let merchant = DefaultSubscriptionMerchant::new(base);
+
+        let catalog = PlanCatalog { plans: vec![], total: 0, page: 1, per_page: 10 };
+
+        let result = merchant.to_standard_plan_catalog(catalog.clone());
+        assert!(result.is_ok());
+        let converted = result.unwrap();
+        assert_eq!(converted.total, catalog.total);
+        assert_eq!(converted.page, catalog.page);
+    }
+
+    #[test]
+    fn test_default_subscription_merchant_subscription_passthrough() {
+        use crate::mcp::subscriptions::{
+            lifecycle::{SubscriptionResponse, SubscriptionStatus},
+            models::{PlanId, SubscriptionId},
+        };
+
+        let base = DefaultMerchant::new();
+        let merchant = DefaultSubscriptionMerchant::new(base);
+
+        let sub_response = SubscriptionResponse {
+            data: crate::mcp::subscriptions::lifecycle::SubscriptionData {
+                id: SubscriptionId::new("sub-test").unwrap(),
+                plan_id: PlanId::new("plan-test").unwrap(),
+                consumer_id: "consumer-test".to_owned(),
+                quantity: 1,
+                created_at: chrono::Utc::now(),
+                current_period_start: chrono::Utc::now(),
+                current_period_end: chrono::Utc::now() + chrono::Duration::days(30),
+                billing_address: None,
+                billing_cycle: crate::mcp::subscriptions::models::BillingCycle::Monthly {
+                    anchor_day: 1,
+                },
+                currency: "USD".to_owned(),
+                current_period_amount: rust_decimal::Decimal::new(999, 2),
+                payment_method_id: None,
+                metadata: serde_json::Value::Null,
+                state_data: crate::mcp::subscriptions::lifecycle::StateData::Active {
+                    activated_at: chrono::Utc::now(),
+                    last_payment_at: None,
+                },
+            },
+            status: SubscriptionStatus::Active,
+        };
+
+        let result = merchant.to_standard_subscription(sub_response.clone());
+        assert!(result.is_ok());
+        let converted = result.unwrap();
+        assert_eq!(converted.status, sub_response.status);
+        assert_eq!(converted.data.id, sub_response.data.id);
+    }
+}

--- a/tap-mcp-bridge/src/reliability/retry.rs
+++ b/tap-mcp-bridge/src/reliability/retry.rs
@@ -249,7 +249,9 @@ pub fn is_retryable(error: &BridgeError) -> bool {
         | BridgeError::CryptoError(_)
         | BridgeError::InvalidMerchantUrl(_)
         | BridgeError::InvalidConsumerId(_)
-        | BridgeError::InvalidInput(_) => false,
+        | BridgeError::InvalidInput(_)
+        | BridgeError::InvalidPlanId(_)
+        | BridgeError::InvalidSubscriptionId(_) => false,
         // Don't retry merchant protocol errors
         BridgeError::MerchantError(_) => false,
         // Don't retry merchant configuration errors
@@ -266,6 +268,14 @@ pub fn is_retryable(error: &BridgeError) -> bool {
         BridgeError::TransportError(_) => false,
         // Don't retry unsupported protocol errors (configuration issue)
         BridgeError::UnsupportedProtocol(_) => false,
+        // Don't retry subscription errors (business logic failures)
+        BridgeError::SubscriptionError(_)
+        | BridgeError::InvalidStateTransition { .. }
+        | BridgeError::UsageError(_)
+        | BridgeError::ProrationError(_)
+        | BridgeError::PaymentMethodChangeError(_)
+        | BridgeError::SubscriptionNotFound(_)
+        | BridgeError::PlanNotFound(_) => false,
     }
 }
 


### PR DESCRIPTION
## Summary

Implements complete subscription support for TAP-MCP Bridge enabling AI agents to manage recurring payments, usage-based billing, and subscription lifecycles.

### Subscription Types Supported

| Type | Example |
|------|---------|
| Flat Rate | $9.99/month |
| Tiered | Basic $10, Pro $25, Enterprise $100 |
| Per-Seat | $5/user/month |
| Usage-Based | $0.01/API call |
| Hybrid | Base $20 + $0.05/request over 1000 |
| One-Time + Expiry | License valid 12 months |

### MCP Tools (12 operations)

| Tool | Description |
|------|-------------|
| `get_subscription_plans` | List available plans |
| `get_subscription_plan` | Get plan details |
| `create_subscription` | Subscribe to plan |
| `get_subscription` | Get subscription details |
| `update_subscription` | Upgrade/downgrade |
| `cancel_subscription` | Cancel subscription |
| `pause_subscription` | Pause billing |
| `resume_subscription` | Resume billing |
| `report_usage` | Report metered usage |
| `get_usage` | Get usage summary |
| `update_payment_method` | Change payment method |
| `preview_proration` | Preview upgrade/downgrade cost |

### Architecture

- **Typestate pattern** for subscription lifecycle - invalid state transitions are compile-time errors
- **Sealed trait** for `SubscriptionMerchantApi` - controlled extension of merchant abstraction
- **APC integration** for payment method encryption
- **TOML configuration** for merchant customization

### Security Hardening

- URL path injection protection (alphanumeric IDs only)
- Query parameter encoding
- Decimal overflow protection in proration calculations
- Negative refund validation
- Grace period bounds validation (1-365 days)
- Usage quantity limits and timestamp validation

### Performance

- LazyLock HTTP client for connection pooling (eliminates per-request allocation)

### Files Changed

**New modules:**
- `mcp/subscriptions/` - models, pricing, lifecycle, tools, proration
- `merchant/subscription_config.rs` - TOML configuration
- `merchant/subscription_traits.rs` - SubscriptionMerchantApi trait

**Modified:**
- `error.rs` - 9 new subscription error variants
- `reliability/retry.rs` - subscription error retry handling

## Test plan

- [x] 630 tests pass (`cargo nextest run --all-features`)
- [x] 136 new subscription-specific tests
- [x] Security review completed (path injection, overflow, validation)
- [x] Performance review completed (HTTP client sharing)
- [x] Code review completed