### PR TITLE
ci(release): switch crates.io publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,27 +93,35 @@ jobs:
       - name: Verify package
         run: cargo package --package tap-mcp-bridge --allow-dirty
 
-  # Publish to crates.io
+  # Publish to crates.io via Trusted Publishing (OIDC)
   publish:
     name: Publish to crates.io
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: release
     permissions:
+      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: "release-publish"
 
+      - name: Authenticate with crates.io (OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish tap-mcp-bridge
-        run: cargo publish --package tap-mcp-bridge --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --package tap-mcp-bridge --no-verify
 
   # Create GitHub Release
   release:


### PR DESCRIPTION
## Summary

Migrates the release workflow from a long-lived \`CARGO_REGISTRY_TOKEN\` secret to crates.io Trusted Publishing (OIDC), mirroring the setup used in \`zeph\`.

- \`rust-lang/crates-io-auth-action@v1\` issues a short-lived token per run
- New \`environment: release\` gate on the publish job
- \`id-token: write\` permission added for OIDC token exchange
- Publish job now runs on stable toolchain with \`--no-verify\` (verification handled by the preceding \`verify\` job)

## Required configuration before next release

1. **crates.io** → \`tap-mcp-bridge\` settings → Trusted Publishers: add \`bug-ops/tap-mcp-bridge\`, workflow \`release.yml\`, environment \`release\`
2. **GitHub** → Settings → Environments: create \`release\` environment (optional protection rules: required reviewers, restrict to \`v*\` tags)
3. After first successful publish, the \`CARGO_REGISTRY_TOKEN\` repository secret can be removed

## Test plan

- [ ] Workflow passes \`actionlint\`/CI parsing on PR
- [ ] After merge + setup steps above, next \`v*\` tag push publishes \`tap-mcp-bridge\` via OIDC without a secret token