### PR TITLE
fix(server): await RunningService::waiting() so server outlives initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `tap-mcp-server` exited immediately after responding to `initialize`, dropping every subsequent request. Under rmcp 1.5, `Service::serve(transport)` resolves at initialization and returns a `RunningService` whose background task drives the request loop; the server now awaits `RunningService::waiting()` so the connection lives for its full lifetime (#118)
+
 ## [0.3.0] - 2026-05-01
 
 ### Added

--- a/tap-mcp-server/src/main.rs
+++ b/tap-mcp-server/src/main.rs
@@ -448,10 +448,16 @@ async fn main() -> Result<()> {
     // Serve on stdio transport with graceful shutdown
     let transport = transport::stdio();
 
-    // Run server with graceful shutdown
+    // `Service::serve` resolves once the service is initialized and returns a
+    // `RunningService` whose background task drives the request loop. Awaiting
+    // `serve` directly would race the loop and cause the binary to exit right
+    // after `initialize`, dropping every subsequent request.
+    let running = server.serve(transport).await.context("Server initialization failed")?;
+
     tokio::select! {
-        result = server.serve(transport) => {
-            result.context("Server execution failed")?;
+        result = running.waiting() => {
+            let quit_reason = result.context("Server task join failed")?;
+            info!(?quit_reason, "Server task finished");
         }
         _ = tokio::signal::ctrl_c() => {
             info!("Received shutdown signal (Ctrl+C)");


### PR DESCRIPTION
## Summary

- Fixes #118 — under rmcp 1.5 the server exited immediately after `initialize`, dropping every subsequent request.
- `Service::serve(transport)` resolves at initialization and returns a `RunningService` whose background task drives the request loop. Server now awaits `RunningService::waiting()` so the connection lives for its full lifetime.
- `tokio::signal::ctrl_c` shutdown path is preserved; if it fires, `RunningService` is dropped and its drop guard cancels the background task.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (619/619)
- [x] Live multi-message conversation: `initialize` → `notifications/initialized` → `tools/list` → `tools/call(verify_agent_identity)` — all three responses arrive (cf. issue #118 reproduction); server logs `quit_reason=Closed` only after stdin EOF