### PR TITLE
fix(mcp): strip trailing slash from base URL when composing request URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `tap-mcp-server` exited immediately after responding to `initialize`, dropping every subsequent request. Under rmcp 1.5, `Service::serve(transport)` resolves at initialization and returns a `RunningService` whose background task drives the request loop; the server now awaits `RunningService::waiting()` so the connection lives for its full lifetime (#118)
+- Merchant request URLs no longer contain a duplicated separator (`https://host//checkout`) when the configured `merchant_url` has no trailing slash. `Url::Display` always emits a trailing `/` for an origin with an empty path, and the previous `format!("{url}{path}")` concatenation produced the wrong wire path on every checkout/browse call. The wire path now matches the `@path` value used to build the RFC 9421 signature base, fixing verification against strict merchants. Introduces `compose_request_url` which preserves the base URL's path prefix and ensures exactly one slash between segments (#116)
 
 ## [0.3.0] - 2026-05-01
 

--- a/tap-mcp-bridge/src/mcp/http.rs
+++ b/tap-mcp-bridge/src/mcp/http.rs
@@ -44,6 +44,25 @@ impl HttpMethod {
 /// Maximum length for search parameters (defense in depth).
 const MAX_SEARCH_PARAM_LENGTH: usize = 256;
 
+/// Composes the wire URL for a TAP request from a parsed base URL and a path.
+///
+/// `Url::Display` always emits a trailing slash for an origin with an empty
+/// path, so naively writing `format!("{url}{path}")` produces `https://host//path`
+/// when `path` itself begins with `/`. That mismatched wire path also breaks
+/// RFC 9421 verification on strict merchants because the signature is built
+/// against the input `path` (`/checkout`), not the doubled form.
+///
+/// This helper preserves the base URL's path prefix, if any, and ensures
+/// exactly one slash sits between the base and the appended path.
+pub(crate) fn compose_request_url(base: &Url, path: &str) -> String {
+    let base_str = base.as_str().trim_end_matches('/');
+    if path.starts_with('/') {
+        format!("{base_str}{path}")
+    } else {
+        format!("{base_str}/{path}")
+    }
+}
+
 /// Creates a configured HTTP client with connection pooling.
 ///
 /// Configuration:
@@ -142,7 +161,7 @@ pub async fn execute_tap_request_with_acro<T: Serialize>(
     let signature =
         signer.sign_request(method.as_str(), authority, path, &body, interaction_type)?;
 
-    let full_url = format!("{url}{path}");
+    let full_url = compose_request_url(&url, path);
     let request = match method {
         HttpMethod::Get => client.get(&full_url),
         HttpMethod::Post => client.post(&full_url),
@@ -222,7 +241,7 @@ pub async fn execute_tap_request_with_custom_nonce<T: Serialize>(
     let signature =
         signer.sign_request(method.as_str(), authority, path, &body, interaction_type)?;
 
-    let full_url = format!("{url}{path}");
+    let full_url = compose_request_url(&url, path);
     let request = match method {
         HttpMethod::Get => client.get(&full_url),
         HttpMethod::Post => client.post(&full_url),
@@ -306,6 +325,57 @@ mod tests {
     fn test_create_http_client() {
         let client = create_http_client();
         assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_compose_request_url_no_trailing_slash() {
+        let base = Url::parse("https://merchant.example.com").unwrap();
+        assert_eq!(
+            compose_request_url(&base, "/checkout"),
+            "https://merchant.example.com/checkout"
+        );
+    }
+
+    #[test]
+    fn test_compose_request_url_trailing_slash() {
+        let base = Url::parse("https://merchant.example.com/").unwrap();
+        assert_eq!(
+            compose_request_url(&base, "/checkout"),
+            "https://merchant.example.com/checkout"
+        );
+    }
+
+    #[test]
+    fn test_compose_request_url_preserves_path_prefix() {
+        let base = Url::parse("https://merchant.example.com/api/v1").unwrap();
+        assert_eq!(
+            compose_request_url(&base, "/checkout"),
+            "https://merchant.example.com/api/v1/checkout"
+        );
+    }
+
+    #[test]
+    fn test_compose_request_url_prefix_with_trailing_slash() {
+        let base = Url::parse("https://merchant.example.com/api/v1/").unwrap();
+        assert_eq!(
+            compose_request_url(&base, "/checkout"),
+            "https://merchant.example.com/api/v1/checkout"
+        );
+    }
+
+    #[test]
+    fn test_compose_request_url_path_without_leading_slash() {
+        let base = Url::parse("https://merchant.example.com").unwrap();
+        assert_eq!(compose_request_url(&base, "checkout"), "https://merchant.example.com/checkout");
+    }
+
+    #[test]
+    fn test_compose_request_url_with_query_string_in_path() {
+        let base = Url::parse("https://merchant.example.com").unwrap();
+        assert_eq!(
+            compose_request_url(&base, "/checkout?intent=payment"),
+            "https://merchant.example.com/checkout?intent=payment"
+        );
     }
 
     #[test]

--- a/tap-mcp-bridge/src/mcp/tools.rs
+++ b/tap-mcp-bridge/src/mcp/tools.rs
@@ -289,9 +289,10 @@ async fn execute_tap_request_with_acro(
 
     let client = &*HTTP_CLIENT;
 
+    let full_url = crate::mcp::http::compose_request_url(&url, &path);
     let request = match method {
-        "POST" => client.post(format!("{url}{path}")),
-        "GET" => client.get(format!("{url}{path}")),
+        "POST" => client.post(&full_url),
+        "GET" => client.get(&full_url),
         _ => {
             return Err(BridgeError::InvalidMerchantUrl(format!(
                 "unsupported HTTP method: {method}"
@@ -346,9 +347,10 @@ async fn execute_tap_request(
 
     let client = &*HTTP_CLIENT;
 
+    let full_url = crate::mcp::http::compose_request_url(&url, &path);
     let request = match method {
-        "POST" => client.post(format!("{url}{path}")),
-        "GET" => client.get(format!("{url}{path}")),
+        "POST" => client.post(&full_url),
+        "GET" => client.get(&full_url),
         _ => {
             return Err(BridgeError::InvalidMerchantUrl(format!(
                 "unsupported HTTP method: {method}"


### PR DESCRIPTION
## Summary

- Fixes #116 — `format!("{url}{path}")` produced `https://host//checkout` whenever `merchant_url` had no trailing slash, because `Url::Display` always emits a trailing `/` for an origin with an empty path.
- Beyond cosmetics, the doubled separator broke RFC 9421 verification on strict merchants: the signature base was built against the input `path` (e.g. `/checkout`), but the wire path was `//checkout` after URL normalization.
- Introduces `compose_request_url(&Url, &str)` in `mcp/http.rs` (pub(crate)) which preserves the base URL's path prefix and guarantees exactly one slash between the base and the appended path. All six call sites — two in `mcp/http.rs`, four in `mcp/tools.rs` — now route through it.

### Out of scope (separate concern, called out in #116)

When `merchant_url` already includes a path prefix (e.g. `https://host.com/api/v1`), `compose_request_url` honors it as a prefix, producing `/api/v1/checkout`. The signed `@path` in the signature base is still the unmodified input `/checkout`, so signing+verification will mismatch for prefix-using merchants. That contract decision (replace vs. append) is left untouched here so it can be tracked as its own issue.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (625/625, including 6 new unit tests covering: no trailing slash, trailing slash, path prefix preserved, prefix with trailing slash, path without leading slash, query string in path)
- [x] `cargo test --doc --all-features` (101/101)
- [x] Live verification — running `basic_checkout` and `browse_catalog` examples now logs `https://merchant.example.com/checkout?...` and `https://merchant-{a,b,c}.example.com/catalog?...` (single slash) instead of the previous `//`