### PR TITLE
fix(server): override get_info to advertise tap-mcp-server identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `tap-mcp-server` exited immediately after responding to `initialize`, dropping every subsequent request. Under rmcp 1.5, `Service::serve(transport)` resolves at initialization and returns a `RunningService` whose background task drives the request loop; the server now awaits `RunningService::waiting()` so the connection lives for its full lifetime (#118)
 - Merchant request URLs no longer contain a duplicated separator (`https://host//checkout`) when the configured `merchant_url` has no trailing slash. `Url::Display` always emits a trailing `/` for an origin with an empty path, and the previous `format!("{url}{path}")` concatenation produced the wrong wire path on every checkout/browse call. The wire path now matches the `@path` value used to build the RFC 9421 signature base, fixing verification against strict merchants. Introduces `compose_request_url` which preserves the base URL's path prefix and ensures exactly one slash between segments (#116)
+- `tap-mcp-server` advertised itself as `rmcp/1.5.0` in the `initialize` response because rmcp's default `Implementation::from_build_env` captures `env!("CARGO_*")` inside the rmcp crate. `ServerHandler::get_info` is now overridden on `TapMcpServer` to return `tap-mcp-server` and the workspace version, giving MCP clients the correct identity (#117)
 
 ## [0.3.0] - 2026-05-01
 

--- a/tap-mcp-server/src/main.rs
+++ b/tap-mcp-server/src/main.rs
@@ -39,7 +39,8 @@ use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     handler::server::{tool::ToolRouter, wrapper::Parameters},
     model::{
-        CallToolRequestParams, CallToolResult, Content, ListToolsResult, PaginatedRequestParams,
+        CallToolRequestParams, CallToolResult, Content, Implementation, ListToolsResult,
+        PaginatedRequestParams, ServerInfo,
     },
     schemars,
     schemars::JsonSchema,
@@ -382,6 +383,17 @@ impl TapMcpServer {
 }
 
 impl ServerHandler for TapMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        // Default `ServerInfo` reports `rmcp` / rmcp's own version, because
+        // `Implementation::from_build_env` captures `env!("CARGO_*")` inside
+        // the rmcp crate. Override with this binary's identity so MCP clients
+        // see `tap-mcp-server` instead of the framework name.
+        ServerInfo::default().with_server_info(Implementation::new(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+        ))
+    }
+
     async fn list_tools(
         &self,
         _pagination: Option<PaginatedRequestParams>,
@@ -533,5 +545,17 @@ mod tests {
 
         let result = create_signer(&config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_info_reports_binary_identity() {
+        let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+        let signer = TapSigner::new(signing_key, "test-agent", "https://agent.example.com");
+        let server = TapMcpServer::new(signer, "test-agent");
+
+        let info = server.get_info().server_info;
+        assert_eq!(info.name, env!("CARGO_PKG_NAME"));
+        assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+        assert_ne!(info.name, "rmcp");
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #117 — MCP `initialize` advertised `serverInfo: { name: "rmcp", version: "1.5.0" }` instead of `tap-mcp-server / 0.3.0`.
- Root cause: rmcp's default `ServerHandler::get_info` calls `Implementation::from_build_env`, which expands `env!("CARGO_*")` inside the rmcp crate at compile time and therefore captures the framework's identity, not the binary's.
- `TapMcpServer` now overrides `get_info` and builds `Implementation::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))`. Because the macro expands inside `tap-mcp-server`, the values resolve to this binary's name and version.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (626/626, including new `test_get_info_reports_binary_identity`)
- [x] Live verification — `initialize` round-trip now returns `serverInfo: { "name": "tap-mcp-server", "version": "0.3.0" }`. Confirmed via:
      ```bash
      ( printf '%s' '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"l","version":"1"}}}'$'\n'; sleep 2 ) | cargo run -q -p tap-mcp-server | jq -r '.result.serverInfo'
      ```