### PR TITLE
feat(security): add TAP_ALLOW_LOOPBACK escape hatch in parse_merchant_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `TAP_ALLOW_LOOPBACK=1` developer escape hatch in `parse_merchant_url`: when set, the function accepts `http://localhost`, `http://127.0.0.1`, and their `https` counterparts so wiremock-style harnesses can drive the full request-response loop end to end. The override is scoped to loopback hosts — non-loopback `http://` URLs are still rejected — and is documented as dev-only; it must never be set in production (#126)
+
 ### Fixed
 
 - `tap-mcp-server` exited immediately after responding to `initialize`, dropping every subsequent request. Under rmcp 1.5, `Service::serve(transport)` resolves at initialization and returns a `RunningService` whose background task drives the request loop; the server now awaits `RunningService::waiting()` so the connection lives for its full lifetime (#118)

--- a/tap-mcp-bridge/src/mcp/tools.rs
+++ b/tap-mcp-bridge/src/mcp/tools.rs
@@ -399,17 +399,47 @@ pub(crate) fn validate_consumer_id(consumer_id: &str) -> Result<()> {
 }
 
 /// Parses and validates merchant URL.
+///
+/// Production policy rejects any URL that is not `https://` and any URL whose
+/// host is `localhost` or `127.0.0.1`. For local end-to-end testing against
+/// loopback-bound mocks (e.g. `wiremock`), set `TAP_ALLOW_LOOPBACK=1` in the
+/// process environment: the function will then accept `http://localhost`,
+/// `http://127.0.0.1`, and their `https` counterparts. The override is
+/// scoped to loopback hosts — non-loopback `http://` URLs are still rejected.
+///
+/// `TAP_ALLOW_LOOPBACK` is a developer escape hatch and must never be set in
+/// production: it disables HTTPS enforcement on the loopback interface and
+/// exposes signed TAP requests over plaintext.
 pub(crate) fn parse_merchant_url(url_str: &str) -> Result<url::Url> {
+    parse_merchant_url_with_policy(url_str, loopback_allowed_via_env())
+}
+
+/// Returns `true` when `TAP_ALLOW_LOOPBACK` is set to `1`.
+fn loopback_allowed_via_env() -> bool {
+    std::env::var("TAP_ALLOW_LOOPBACK").is_ok_and(|v| v == "1")
+}
+
+/// Pure policy helper used by [`parse_merchant_url`].
+///
+/// Splitting the env-var read from the URL validation lets unit tests
+/// exercise both branches without mutating process state.
+fn parse_merchant_url_with_policy(url_str: &str, allow_loopback: bool) -> Result<url::Url> {
     let url = url::Url::parse(url_str)
         .map_err(|e| BridgeError::InvalidMerchantUrl(format!("parse error: {e}")))?;
 
-    if url.scheme() != "https" {
+    let is_loopback_host =
+        matches!(url.host_str(), Some(h) if h == "localhost" || h == "127.0.0.1");
+
+    let scheme_ok = match url.scheme() {
+        "https" => true,
+        "http" => allow_loopback && is_loopback_host,
+        _ => false,
+    };
+    if !scheme_ok {
         return Err(BridgeError::InvalidMerchantUrl("URL must use HTTPS".into()));
     }
 
-    if let Some(host) = url.host_str()
-        && (host == "localhost" || host == "127.0.0.1" || host.starts_with("localhost:"))
-    {
+    if is_loopback_host && !allow_loopback {
         return Err(BridgeError::InvalidMerchantUrl("localhost URLs not allowed".into()));
     }
 
@@ -496,6 +526,50 @@ mod tests {
     fn test_parse_merchant_url_ws_rejected() {
         let url = parse_merchant_url("ws://merchant.com");
         assert!(url.is_err());
+    }
+
+    #[test]
+    fn test_parse_merchant_url_with_policy_default_rejects_http_loopback() {
+        let url = parse_merchant_url_with_policy("http://127.0.0.1:1234", false);
+        assert!(matches!(url, Err(BridgeError::InvalidMerchantUrl(_))));
+    }
+
+    #[test]
+    fn test_parse_merchant_url_with_policy_default_rejects_https_loopback() {
+        let url = parse_merchant_url_with_policy("https://localhost:1234", false);
+        assert!(matches!(url, Err(BridgeError::InvalidMerchantUrl(_))));
+    }
+
+    #[test]
+    fn test_parse_merchant_url_with_policy_loopback_accepts_http_127001() {
+        let url = parse_merchant_url_with_policy("http://127.0.0.1:8080/api", true);
+        assert!(url.is_ok(), "expected http://127.0.0.1 to be accepted: {url:?}");
+    }
+
+    #[test]
+    fn test_parse_merchant_url_with_policy_loopback_accepts_http_localhost() {
+        let url = parse_merchant_url_with_policy("http://localhost:3000", true);
+        assert!(url.is_ok(), "expected http://localhost to be accepted: {url:?}");
+    }
+
+    #[test]
+    fn test_parse_merchant_url_with_policy_loopback_accepts_https_loopback() {
+        let url = parse_merchant_url_with_policy("https://127.0.0.1:1234", true);
+        assert!(url.is_ok(), "expected https://127.0.0.1 to be accepted: {url:?}");
+    }
+
+    #[test]
+    fn test_parse_merchant_url_with_policy_loopback_still_rejects_http_remote() {
+        // The override is scoped to loopback hosts — plaintext to a remote host
+        // remains rejected even with allow_loopback=true.
+        let url = parse_merchant_url_with_policy("http://merchant.com", true);
+        assert!(matches!(url, Err(BridgeError::InvalidMerchantUrl(_))));
+    }
+
+    #[test]
+    fn test_parse_merchant_url_with_policy_loopback_still_rejects_ws() {
+        let url = parse_merchant_url_with_policy("ws://127.0.0.1:1234", true);
+        assert!(matches!(url, Err(BridgeError::InvalidMerchantUrl(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `TAP_ALLOW_LOOPBACK=1` developer escape hatch in `parse_merchant_url`. When set, the function accepts `http://localhost`, `http://127.0.0.1`, and their `https` counterparts so wiremock-style harnesses can drive the full request-response loop end to end (signature-base/wire-path equality, retry on 5xx, circuit-breaker transitions, replay-cache concurrency, response parsing).
- The override is scoped to loopback hosts: non-loopback `http://` URLs are still rejected, and non-http(s) schemes (`ftp`, `ws`, ...) remain rejected unconditionally. Default behaviour is unchanged when the env var is unset or set to anything other than `1`.
- Splits the policy decision into a pure helper `parse_merchant_url_with_policy(url, allow_loopback)` so unit tests cover both branches without mutating process state.

Closes #126.

## Test plan

- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (636 passed, including 7 new tests for the policy helper)
- [x] `cargo test --doc --all-features` (101 passed)
- [x] `RUSTDOCFLAGS="--deny rustdoc::broken_intra_doc_links" cargo doc --no-deps --all-features`