### PR TITLE
release: v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-05-26
+
 ### Added
 
 - `TAP_ALLOW_LOOPBACK=1` developer escape hatch in `parse_merchant_url`: when set, the function accepts `http://localhost`, `http://127.0.0.1`, and their `https` counterparts so wiremock-style harnesses can drive the full request-response loop end to end. The override is scoped to loopback hosts — non-loopback `http://` URLs are still rejected — and is documented as dev-only; it must never be set in production (#126)
@@ -45,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tap-mcp-server` now exposes the full e-commerce flow as MCP tools, mirroring the library's public functions: `get_products`, `get_product`, `add_to_cart`, `get_cart`, `update_cart_item`, `remove_from_cart`, `create_order`, `get_order`, `process_payment`. Together with the existing `checkout_with_tap`, `browse_merchant`, `verify_agent_identity` the server now lists 12 tools (#121)
 
 ## [0.3.0] - 2026-05-01
+
 
 ### Added
 
@@ -317,7 +320,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/bug-ops/tap-mcp-bridge/releases/tag/v0.2.0
 [0.1.2]: https://github.com/bug-ops/tap-mcp-bridge/releases/tag/v0.1.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,7 +2330,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tap-mcp-bridge"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "tap-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 rust-version = "1.94"
 authors = ["Andrei G. <andrei.g@my.com>"]
 license = "MIT OR Apache-2.0"
-version = "0.3.0"
+version = "0.3.1"
 repository = "https://github.com/bug-ops/tap-mcp-bridge"
 
 # Dependencies are sorted alphabetically.
@@ -31,8 +31,8 @@ serde = "1"
 serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.11"
 signature = "3"
-tap-mcp-bridge = { version = "0.3.0", path = "tap-mcp-bridge" }
-tap-mcp-server = { version = "0.3.0", path = "tap-mcp-server" }
+tap-mcp-bridge = { version = "0.3.1", path = "tap-mcp-bridge" }
+tap-mcp-server = { version = "0.3.1", path = "tap-mcp-server" }
 thiserror = "2"
 tokio = "1"
 toml = "1.0"


### PR DESCRIPTION
## Summary

- Bump version from 0.3.0 to 0.3.1
- Update CHANGELOG.md with release notes for v0.3.1
- Update workspace dependency version pins in root Cargo.toml

## Checklist

- [x] Version updated in root Cargo.toml workspace (members inherit via `version.workspace = true`)
- [x] Workspace dependency pins updated to 0.3.1
- [x] Cargo.lock updated
- [x] CHANGELOG.md has `[0.3.1] - 2026-05-26` section with full release notes
- [x] Comparison links updated (`[Unreleased]` and `[0.3.1]`)
- [x] `cargo +nightly fmt --check` passes
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` passes
- [x] `cargo nextest run --workspace --all-features --lib --bins` passes (689 tests)

## After merge

```
git tag v0.3.1 && git push origin v0.3.1
```