### PR TITLE
release: v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-29
+
+### Fixed
+
+- Remove unused `async` from `list_tools` trait impl in `tap-mcp-server` (#192)
+
+### Changed
+
+#### Dependencies
+
+- `rmcp` 1.7.0 → 1.8.0
+- `ed25519-dalek` 3.0.0-pre.7 → 3.0.0-rc.1 (via two consecutive Dependabot bumps: #172, #183)
+- `reqwest` 0.13.3 → 0.13.4; `hyper` 1.9.0 → 1.10.1 (#173)
+- `bytes` 1.11.1 → 1.12.0 (#184); `bitvec` 1.0.1 → 1.1.1 (#185); `borsh` 1.6.1 → 1.7.0 (#186)
+- Security-update sweeps: `anyhow` 1.0.102 → 1.0.103, `hybrid-array` 0.4.12 → 0.4.13, `rustls` 0.23.40 → 0.23.41 (#189)
+- Security-update sweeps: `arrayvec` 0.7.6 → 0.7.7, `quinn`/`quinn-proto` 0.11.9 → 0.11.11, `time` 0.3.49 → 0.3.51, `log` 0.4.30 → 0.4.33, `cc` 1.2.62 → 1.2.65 (#179, #188)
+- Security-update sweeps: `chrono` 0.4.44 → 0.4.45, `h2` 0.4.14 → 0.4.15, `http` 1.4.0 → 1.4.2, `memchr` 2.8.0 → 2.8.2, `mio` 1.2.0 → 1.2.1, `rust_decimal` 1.42.0 → 1.42.1, and 15 further transitive updates (#179)
+- `uuid` 1.23.1 → 1.23.4 (dev dep, via #174, #191)
+
+#### CI
+
+- `actions/checkout` v6 → v7 (#181)
+- `codecov/codecov-action` v6 → v7 (#175)
+- `lewagon/wait-on-check-action` bump (#177)
+
 ## [0.3.1] - 2026-05-26
 
 ### Added
@@ -320,7 +345,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bug-ops/tap-mcp-bridge/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/bug-ops/tap-mcp-bridge/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,7 +2317,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tap-mcp-bridge"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "tap-mcp-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 rust-version = "1.94"
 authors = ["Andrei G. <andrei.g@my.com>"]
 license = "MIT OR Apache-2.0"
-version = "0.3.1"
+version = "0.3.2"
 repository = "https://github.com/bug-ops/tap-mcp-bridge"
 
 # Dependencies are sorted alphabetically.
@@ -31,8 +31,8 @@ serde = "1"
 serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.11"
 signature = "3"
-tap-mcp-bridge = { version = "0.3.1", path = "tap-mcp-bridge" }
-tap-mcp-server = { version = "0.3.1", path = "tap-mcp-server" }
+tap-mcp-bridge = { version = "0.3.2", path = "tap-mcp-bridge" }
+tap-mcp-server = { version = "0.3.2", path = "tap-mcp-server" }
 thiserror = "2"
 tokio = "1"
 toml = "1.0"


### PR DESCRIPTION
## Summary

- Bump workspace version 0.3.1 → 0.3.2
- Update CHANGELOG.md with all changes since v0.3.1
- No source code changes — patch release covering dependency updates and one server fix

## Changes since v0.3.1

- `fix(server)`: remove unused `async` from `list_tools` trait impl
- `rmcp` 1.7.0 → 1.8.0
- `ed25519-dalek` 3.0.0-pre.7 → 3.0.0-rc.1
- `reqwest` 0.13.3 → 0.13.4, `hyper` 1.9.0 → 1.10.1
- `rustls` 0.23.40 → 0.23.41, `hybrid-array`, `anyhow`, and 30+ transitive security updates
- CI: `actions/checkout` v6→v7, `codecov/codecov-action` v6→v7

## Checklist

- [x] Version updated in root Cargo.toml (workspace.package.version)
- [x] Internal workspace dep versions updated
- [x] Cargo.lock updated
- [x] CHANGELOG.md has release section with date (2026-06-29)
- [x] All CI checks pass (689 tests, clippy clean, fmt clean)
- [x] Ready for tagging after merge