### PR TITLE
fix(security): allow deprecated fetch_update until try_update stabilizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Suppress deprecation error on `AtomicU64::fetch_update` in `security::rate_limit` — its replacement `try_update` (rust-lang/rust#135894) is not yet stable on the project's MSRV, and `-D warnings` was failing the build under newer toolchains
+
 ## [0.3.2] - 2026-06-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/tap-mcp-bridge/src/security/rate_limit.rs
+++ b/tap-mcp-bridge/src/security/rate_limit.rs
@@ -279,6 +279,11 @@ impl RateLimiter {
             let max_tokens = u64::from(self.config.burst_size) * 1000;
 
             // Add tokens up to the maximum
+            #[allow(
+                deprecated,
+                reason = "try_update (rust-lang/rust#135894) is unstable on our MSRV; \
+                          fetch_update is the only stable option until it lands"
+            )]
             self.tokens
                 .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
                     Some(current.saturating_add(tokens_to_add).min(max_tokens))


### PR DESCRIPTION
## Summary

- `AtomicU64::fetch_update` in `tap-mcp-bridge/src/security/rate_limit.rs` is now deprecated in favor of `try_update`, but `try_update` (rust-lang/rust#135894) is still unstable on the project's pinned MSRV (1.94). With workspace-wide `-D warnings`, this deprecation notice fails compilation across most CI jobs (`Build Server Binary`, `Check MSRV`, `Build Tests`, `Check`, `Check Dependencies`, `Feature Combinations`), which is what is currently blocking PR #194.
- Adds a scoped `#[allow(deprecated)]` with a `reason` on the single call site until `try_update` stabilizes on our MSRV.

## Test plan

- [x] `cargo +nightly check -p tap-mcp-bridge --all-features` (RUSTFLAGS=-D warnings)
- [x] `cargo +1.94 check -p tap-mcp-bridge --all-features --locked` (RUSTFLAGS=-D warnings)
- [x] `cargo +nightly clippy --all-targets --all-features --workspace -- -D warnings`
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo nextest run --workspace --all-features --lib --bins` (689 passed)