### PR TITLE
docs: migrate specs to shared specs directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MOC-specs.md` moved as-is, with internal `.local/specs/` path references updated to
   `specs/`. `.local/specs/` remains reserved for scratch/working documents per this
   project's convention; durable specs now live in `specs/` and are part of the repo history
+- Added 9 subsystem specs (`012`–`020`) documenting the current, as-built behavior of
+  every logical subsystem tracked in `.claude/rules/continuous-improvement.md` §
+  Project Subsystems (`tap`, `jwe`, `mcp`, `merchant`, `transport`, `reliability`,
+  `security`, `observability`, `tap-mcp-server`), none of which previously had
+  dedicated spec coverage — the existing 11 specs are individual bug-fix/finding
+  specs, not subsystem-level documentation. These specs describe existing, tested
+  code; they do not propose new functionality
 
 #### Lints
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved the SDD spec archive from the untracked `.local/specs/` working folder to a
+  git-tracked top-level `specs/` directory, mirroring the convention used by sibling
+  projects (zeph, exarch, mcp-execution). All 11 existing specs (`001`–`011`) and
+  `MOC-specs.md` moved as-is, with internal `.local/specs/` path references updated to
+  `specs/`. `.local/specs/` remains reserved for scratch/working documents per this
+  project's convention; durable specs now live in `specs/` and are part of the repo history
+
 #### Lints
 
 - `unsafe_code` is now `deny` at the workspace level (`Cargo.toml` `[workspace.lints.rust]`) instead of being unrestricted. The sole existing `unsafe` block (a test-only `std::env::set_var`/`remove_var` sequence in `tap-mcp-server/src/observability.rs`) now carries a scoped `#[allow(unsafe_code, reason = "...")]` on the test function alongside its existing `SAFETY` comment. Any future `unsafe` usage requires the same point exception plus justification — see `CLAUDE.md` Conventions.

--- a/specs/001-cart-id-silently-dropped/spec.md
+++ b/specs/001-cart-id-silently-dropped/spec.md
@@ -1,0 +1,119 @@
+# Spec 001 — `update_cart_item` and `remove_from_cart` silently drop required `cart_id`
+
+**Status**: Draft
+**Priority**: P1 (High)
+**Type**: Bug fix
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 7 live testing, master @ 9aa61b3
+**Source**: live-test harness `.local/testing/scratch/src/wire_drive.rs`
+
+## Problem Statement
+
+Two MCP tools — `update_cart_item` and `remove_from_cart` — accept `cart_id` as a
+**required** parameter in both their library `Params` struct and the MCP
+`tools/list` schema, but the library implementations **never read the field
+when constructing the outbound HTTP request**. As a result:
+
+- A merchant receiving the request has no way to know which cart context
+  applies, breaking the multi-cart-per-consumer semantics.
+- The MCP API contract is violated: clients are required to supply a value
+  that is silently discarded — they have no way to detect that this happened.
+- Symmetric tools (`add_to_cart`, `get_cart`) correctly transmit `cart_id`.
+  The asymmetry is a latent contract bug, not a deliberate design choice.
+
+## User Stories
+
+- **As a TAP-MCP client developer** building an agent that maintains multiple
+  shopping carts per consumer, I need `update_cart_item` and `remove_from_cart`
+  to operate on the cart I specify so that operations on cart A do not
+  accidentally affect cart B.
+- **As a merchant API operator**, I need the request to disambiguate between
+  carts so that my server can route the operation correctly without inventing
+  state inference (e.g. "most recent cart").
+- **As a security reviewer**, I need declared required parameters to actually
+  reach the wire, otherwise the schema is misleading and review is unsound.
+
+## Functional Requirements
+
+**FR-1**: When a caller invokes `update_cart_item` with a `cart_id` value,
+that value MUST be present in the outbound HTTP request in at least one of:
+URL path, query string, or request body.
+
+**FR-2**: When a caller invokes `remove_from_cart` with a `cart_id` value,
+that value MUST be present in the outbound HTTP request in at least one of:
+URL path, query string, or request body.
+
+**FR-3**: The `cart_id` placement chosen for FR-1 and FR-2 SHOULD be
+consistent with the project's existing convention: `add_to_cart` uses the
+request body; `get_cart` uses the query string. The chosen placement should
+match one of these or be documented as a deliberate departure.
+
+**FR-4**: The RFC 9421 `@path` signature component MUST cover the chosen
+placement so that a man-in-the-middle cannot rewrite `cart_id` in transit
+without invalidating the signature. (Path/query are already covered by
+`@path`; a body placement is covered by `Content-Digest`.)
+
+**FR-5**: If, after design review, `cart_id` is determined to be unnecessary
+for these endpoints (i.e. the merchant API is item-id-keyed and cart context
+is implicit), the `cart_id` field MUST be removed from `UpdateCartItemParams`,
+`RemoveFromCartParams`, and the MCP tool schemas, with a CHANGELOG entry
+documenting the breaking change.
+
+## Non-Functional Requirements
+
+- **Backwards compatibility**: pre-1.0 — breaking changes are allowed, must
+  be recorded in `CHANGELOG.md` `[Unreleased]`.
+- **Test coverage**: a regression test in `tap-mcp-bridge/src/mcp/cart.rs`
+  must assert that `cart_id` reaches the wire (or is absent if FR-5 is taken).
+  The wiremock harness at `.local/testing/scratch/src/wire_drive.rs` already
+  covers this and should keep producing zero anomalies after the fix.
+- **Documentation**: the doc comment for both functions must describe where
+  on the wire `cart_id` lands.
+
+## Design Choices (Open Questions for /sdd plan)
+
+The HOW belongs in a follow-up `/sdd plan` session; the spec captures the
+candidate placements:
+
+1. **Path-segment style**: `PUT /cart/{cart_id}/items/{item_id}` and
+   `DELETE /cart/{cart_id}/items/{item_id}`. RESTful, consistent with how a
+   merchant might expose nested resources. Covered by `@path` automatically.
+2. **Query-parameter style**: `PUT /cart/items/{item_id}?cart_id=…&consumer_id=…`
+   (analogous to `get_cart`). Minimal change to existing path. Covered by
+   `@path` (query is part of the request target per RFC 9421 §2.2.6).
+3. **Body style** (PUT only): extend `UpdateCartItemRequest` to include
+   `cart_id`. Asymmetric for DELETE since DELETE has no body convention.
+4. **Drop the field** (FR-5): if the merchant API treats `item_id` as
+   globally unique, `cart_id` is genuinely redundant. Risk: ambiguity if a
+   future merchant has overlapping item IDs across carts.
+
+[NEEDS CLARIFICATION: which placement matches the merchant API convention
+this bridge is designed against (TAP spec or VISA reference implementations)?]
+
+## Reproduction / Evidence
+
+Cycle 7 wiremock harness output (full log: `.local/testing/debug/cycle7/wire_drive.log`):
+
+```
+[ANOMALY] update_cart_item: required cart_id NOT present anywhere on the wire
+  (path="/cart/items/I1", query="consumer_id=user-1", body=14 bytes)
+[ANOMALY] remove_from_cart: required cart_id NOT present anywhere on the wire
+  (path="/cart/items/I1", query="consumer_id=user-1", body=750 bytes)
+```
+
+The 14-byte PUT body is `UpdateCartItemRequest { quantity: 3 }` (JSON: about
+`{"quantity":3}`), no cart_id field exists. The 750-byte DELETE body is the
+ACRO envelope, which carries no cart_id either.
+
+Static reference points:
+- `tap-mcp-bridge/src/mcp/cart.rs:80` — `UpdateCartItemParams.cart_id: String`
+- `tap-mcp-bridge/src/mcp/cart.rs:107` — `RemoveFromCartParams.cart_id: String`
+- `tap-mcp-bridge/src/mcp/cart.rs:241-283` — `update_cart_item` impl, no `cart_id` reference
+- `tap-mcp-bridge/src/mcp/cart.rs:291-331` — `remove_from_cart` impl, no `cart_id` reference
+- `tap-mcp-bridge/src/mcp/cart.rs:135-139` — `UpdateCartItemRequest` body struct, no `cart_id` field
+
+## See Also
+
+- Issue (filed by Cycle 7 with link back to this spec)
+- `add_to_cart` / `get_cart` for the existing patterns
+- TAP spec sections covering merchant cart semantics (if applicable)

--- a/specs/002-json-key-ordering-regression/spec.md
+++ b/specs/002-json-key-ordering-regression/spec.md
@@ -1,0 +1,171 @@
+# Spec 002 — JSON object key ordering changed silently after #130
+
+**Status**: Draft
+**Priority**: P2 (Bug — suboptimal/minor inconsistency / Enhancement — make the contract explicit)
+**Type**: Bug fix or design clarification (depends on chosen direction)
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 9 live testing, master @ d96d657
+**Source**: live-test diff between cycle 7 (`9aa61b3`) and cycle 9 (`d96d657`) MCP smoke transcripts
+
+## Problem Statement
+
+PR #130 (`feat(security)!: replace josekit JWE with aws-lc-rs (drop OpenSSL)`)
+removed `josekit` from the dependency graph. As a transitive side-effect,
+`serde_json` is no longer compiled with the `preserve_order` feature
+(`josekit`'s dep tree had been pulling it in via `indexmap`), and its
+`Value::Object`/`json!{}` macro now uses `BTreeMap` instead of `IndexMap`.
+The result: every JSON object built through `serde_json::json!({…})` is now
+serialized with **alphabetically sorted keys**, while previously the keys
+matched the insertion order in the source.
+
+This change is **not documented** in the #130 PR description, the
+`BREAKING CHANGE` footer (which only mentioned PEM acceptance), or the
+`CHANGELOG.md` `[Unreleased]` entry for #130. It crossed multiple
+serialization boundaries silently:
+
+1. **`tap-mcp-server::observability::HealthReport::to_json`**
+   (`tap-mcp-server/src/observability.rs:223–252`) — produces the body of
+   the MCP `verify_agent_identity` tool response. Cycle 7 emitted the
+   declared order `status, version, agent_id, uptime_secs, checks`; cycle
+   8/9 emit the alphabetical order `agent_id, checks, status, uptime_secs,
+   version` (and inside each `HealthCheck`: previously `name, status,
+   message`, now `message, name, status`).
+2. **`tap_mcp_bridge::tap::apc::PaymentMethod::to_json`**
+   (`tap-mcp-bridge/src/tap/apc.rs:362–396`) — produces the **plaintext
+   that gets RSA-OAEP / AES-256-GCM-encrypted into the APC**. The byte
+   sequence sent over the wire (the JWE ciphertext) is now derived from a
+   different plaintext byte sequence. The decrypted content is functionally
+   identical (same fields, same values), but the byte layout is changed.
+3. **`tap_mcp_bridge::tap::jwt::IdToken::create`**
+   (`tap-mcp-bridge/src/tap/jwt.rs:301–304`) — JWT header `{"alg","typ"}`.
+   The keys `alg < typ` are already alphabetical in the source, so this
+   call site is unaffected in practice.
+
+`#[derive(Serialize)]` structs (e.g. `Apc`, `Acro`, `IdTokenClaims`) are
+**not** affected because serde-derive emits fields in declaration order
+regardless of the `preserve_order` feature.
+
+## User Stories
+
+- **As a downstream consumer** that may snapshot or hash the JSON output of
+  `verify_agent_identity` for monitoring/alerting/audit purposes, I should
+  not see a hash mismatch caused by an unrelated security PR.
+- **As a TAP-MCP bridge maintainer** I should be able to read the
+  `[Unreleased]` section of `CHANGELOG.md` and know about every behavioral
+  change introduced in a PR. A silent change to the JSON serialization of
+  the encrypted APC plaintext bytes is the kind of thing that belongs there.
+- **As a future test author** verifying APC encryption against a TAP
+  reference vector or a known-merchant fixture, I need a stable plaintext
+  byte layout, otherwise reference comparisons drift.
+
+## Functional Requirements
+
+**FR-1**: The project MUST adopt one of the following positions and document
+it explicitly:
+
+  - **Position A — Restore stability**: enable `serde_json/preserve_order`
+    in `tap-mcp-bridge/Cargo.toml` and `tap-mcp-server/Cargo.toml` so JSON
+    object key order matches the source declaration order at all `json!{}`
+    call sites. This restores cycle 7 byte layout.
+  - **Position B — Embrace alphabetical**: keep current alphabetical
+    behavior, document it in `CHANGELOG.md` under the #130 entry, and add
+    a regression test asserting the exact byte layout of `HealthReport`
+    JSON and `PaymentMethod::to_json` for each variant.
+
+**FR-2**: Whichever position is chosen, the regression test MUST cover at
+least:
+  - `HealthReport` round-trip (build → `to_json()` → exact-byte assertion).
+  - `PaymentMethod::Card`, `BankAccount`, `DigitalWallet` round-trips
+    (build → `to_json()` → exact-byte assertion of the inner JSON).
+  - Documentation that explicitly states "key ordering of `json!{}`
+    output is/is-not stable across releases".
+
+**FR-3**: `CHANGELOG.md` MUST be amended (under #130 or a new
+`[Unreleased]` entry, depending on whether 0.3.0 is already published) to
+note the JSON-ordering side-effect.
+
+## Non-Functional Requirements
+
+- **Performance**: enabling `preserve_order` swaps `BTreeMap` for
+  `IndexMap`; the binary cost is one extra hashmap-style data structure
+  pulled into the dep graph (`indexmap`, ~few hundred KB). Negligible.
+- **Backward compatibility**: pre-1.0 — explicit position-A "restore" is
+  itself a breaking change vs the just-released cycle-8 byte layout, but
+  restores parity with the cycle-7 layout that v0.3.0 was tagged on.
+  Position-B accepts the cycle-8 layout as the new normal.
+- **Documentation**: Position A or B must be cross-referenced from the
+  `serde_json` features list to make the choice intentional and stable.
+
+## Design Choices (Open Questions for /sdd plan)
+
+- Is there a TAP/RFC requirement on APC plaintext byte order? RFC 7516
+  (JWE) says nothing about JSON inside the plaintext. RFC 8259 (JSON) says
+  member order is not significant. So no protocol-level requirement.
+- Is there a merchant-side replay or audit hash that depends on exact
+  plaintext bytes? If yes → Position A is mandatory.
+- Position A locks the project into `IndexMap` for the entire dep graph;
+  Position B keeps the dep graph minimal at the cost of unstable byte
+  layout. Position B + an explicit derive struct (instead of `json!{}`) for
+  every order-sensitive JSON object is a third path: zero extra deps, byte-
+  stable, but more code per call site.
+
+[NEEDS CLARIFICATION: confirm with TAP spec authors whether APC plaintext
+byte stability is a protocol invariant.]
+
+## Reproduction / Evidence
+
+Same `verify_agent_identity` MCP smoke run, two master commits.
+
+Cycle 7 (`9aa61b3`) — declared order:
+```
+{
+  "status": "healthy",
+  "version": "0.3.0",
+  "agent_id": "test-agent-1",
+  "uptime_secs": 0,
+  "checks": [
+    {
+      "name": "signing_key",
+      "status": "pass",
+      "message": "Ed25519 signing key loaded successfully"
+    },
+```
+
+Cycle 8 (`d61c2dc`) and Cycle 9 (`d96d657`) — alphabetical:
+```
+{
+  "agent_id": "test-agent-9",
+  "checks": [
+    {
+      "message": "Ed25519 signing key loaded successfully",
+      "name": "signing_key",
+      "status": "pass"
+    },
+```
+
+The dependency graph delta (`Cargo.lock`):
+
+```
+  [[package]]
+  name = "serde_json"
+  version = "1.0.149"
+  ...
+  dependencies = [
+- "indexmap",
+   "itoa",
+   "memchr",
+   "serde",
+   "serde_core",
+   "zmij",
+  ]
+```
+
+`indexmap` is the marker for `serde_json`'s `preserve_order` feature.
+
+## See Also
+
+- Issue (filed by Cycle 9 with link back to this spec)
+- PR #130 (replaces josekit with aws-lc-rs — root cause)
+- `tap-mcp-server/src/observability.rs:223–252` — affected `to_json`
+- `tap-mcp-bridge/src/tap/apc.rs:362–396` — affected APC plaintext builder
+- `tap-mcp-bridge/src/tap/jwt.rs:301–304` — JWT header (incidentally already alphabetical)

--- a/specs/003-rate-limit-not-per-consumer/spec.md
+++ b/specs/003-rate-limit-not-per-consumer/spec.md
@@ -1,0 +1,147 @@
+# Spec 003 — `process_payment_rate_limited` is process-global despite "per consumer" claim
+
+**Status**: Draft
+**Priority**: P1 (Bug — degraded UX / contract violation / multi-tenant DoS surface)
+**Type**: Bug fix or doc correction (depends on chosen direction)
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 11 live testing, master @ 4adf44f
+**Source**: `.local/testing/scratch/src/rate_limit_multi_consumer.rs`
+
+## Problem Statement
+
+The public function `tap_mcp_bridge::mcp::payment::process_payment_rate_limited`
+documents a **per-consumer** rate limit, but the implementation enforces a
+**process-global** rate limit. Any single consumer that exhausts the bucket
+denies service to every other consumer in the same process.
+
+**Doc claims** (`tap-mcp-bridge/src/mcp/payment.rs`):
+- Line 281: `/// Default configuration: 5 payments per minute per consumer`
+- Line 309: `/// Default rate limit: 5 attempts per minute per consumer (burst of 3).`
+
+**Implementation** (lines 282–302): a single
+`static PAYMENT_RATE_LIMITER: Mutex<Option<Arc<RateLimiter>>>` is initialized
+lazily on first call with `requests_per_second=1, burst_size=3`.
+`get_payment_rate_limiter()` returns the same `Arc<RateLimiter>` for every
+caller, regardless of `params.consumer_id`. The `consumer_id` is never read
+when acquiring a token.
+
+In a multi-tenant deployment (e.g. a single bridge process serving many
+end-users), one noisy or malicious consumer exhausts the shared bucket and
+silently rate-limits all other consumers — directly opposite of the
+documented contract.
+
+## User Stories
+
+- **As a multi-tenant bridge operator** I expect that one noisy consumer
+  cannot deny service to other consumers via the rate limiter, because the
+  documented contract says rate limits are per-consumer.
+- **As a security reviewer** I need documented behavior to match
+  implementation: an undocumented global bucket is a covert DoS surface.
+- **As a downstream library consumer** I read the doc-comment, configure
+  my code accordingly, and expect the function to behave as documented. A
+  silent contract mismatch leads to subtle production bugs (e.g. retry
+  loops that exhaust the global bucket and surprise everyone else).
+
+## Functional Requirements
+
+**FR-1**: The project MUST resolve the contract mismatch by adopting one of
+the following positions and document it explicitly:
+
+  - **Position A — Implement per-consumer limiting**: replace the
+    process-global static with a per-consumer keyed structure (e.g.
+    `DashMap<String, Arc<RateLimiter>>` or a sharded LRU of limiters).
+    Each consumer_id gets its own bucket. Matches the current doc-comment.
+  - **Position B — Correct the documentation**: change both doc-comments
+    on `payment.rs:281` and `:309` to say "per process" / "shared across
+    consumers" and update the `CHANGELOG.md` to note the behavior. The
+    current behavior remains; only the docs are fixed.
+
+**FR-2**: Whichever position is chosen, a regression test MUST exist that
+asserts the chosen scope. For Position A, two distinct consumer_ids must
+each be able to drain their own burst without blocking each other. For
+Position B, the test asserts that two consumer_ids share the bucket.
+
+**FR-3**: If Position A is chosen, the per-consumer storage MUST have a
+bounded size with eviction (LRU or TTL) so that an attacker submitting
+millions of distinct consumer_ids cannot exhaust process memory. The
+default size and eviction policy MUST be documented.
+
+**FR-4**: The MCP tool surface (`process_payment` registered in
+`tap-mcp-server`) does NOT currently call `process_payment_rate_limited`.
+The MCP path uses the unrate-limited `process_payment` function directly.
+This is orthogonal to FR-1/FR-2 but should be reviewed: if the MCP path
+needs rate limiting, it should be wired explicitly. If it doesn't need it,
+say so in the doc.
+
+## Non-Functional Requirements
+
+- **Performance**: per-consumer keyed lookups should remain O(log n) or
+  O(1) on the hot path. Avoid taking a global mutex for every call.
+- **Memory**: bounded — see FR-3.
+- **Observability**: rate-limit rejections should log the consumer_id so
+  operators can identify the noisy tenant.
+- **Documentation**: the chosen position must be reflected in
+  `CHANGELOG.md` and in the function's `# Errors` section.
+
+## Design Choices (Open Questions for /sdd plan)
+
+- **Position A — DashMap of limiters**: simple, common pattern. Memory
+  overhead = ~tracker_size * unique_consumers; needs eviction.
+- **Position A — Sharded LRU**: bounds memory by construction; one mutex
+  per shard avoids contention.
+- **Position A — token-bucket per consumer with global ceiling**: hybrid
+  that protects the process from cross-consumer flooding while still
+  giving each consumer their own limit. More complex to reason about.
+- **Position B — accept process-global**: simplest; matches current code;
+  fixes only the docs. Multi-tenant operators must layer their own
+  per-consumer rate limiting upstream of the bridge.
+
+[NEEDS CLARIFICATION: is this bridge intended for single-tenant or
+multi-tenant deployment? The CHANGELOG / README don't say explicitly. The
+choice between Position A and B hinges on this.]
+
+## Reproduction / Evidence
+
+Cycle 11 live test (`rate-limit-multi-consumer` harness):
+
+```
+=== rate-limit-multi-consumer: per-consumer scope probe ===
+[A] 3 calls as 'alice' (drains alice's documented per-consumer burst)
+  alice call 1: Ok
+  alice call 2: Ok
+  alice call 3: Ok
+[B] bob's first call: RateLimitExceeded     ← expected Ok per docs
+[B] bob's second call: RateLimitExceeded
+[C] charlie's first call: RateLimitExceeded
+
+GLOBAL scope detected: bob/charlie blocked because alice drained the shared bucket
+```
+
+Static evidence — `tap-mcp-bridge/src/mcp/payment.rs:282–302`:
+
+```rust
+static PAYMENT_RATE_LIMITER: Mutex<Option<Arc<RateLimiter>>> = Mutex::new(None);
+
+fn get_payment_rate_limiter() -> Arc<RateLimiter> {
+    let mut limiter_opt = PAYMENT_RATE_LIMITER.lock()...;
+    if let Some(limiter) = limiter_opt.as_ref() {
+        Arc::clone(limiter)
+    } else {
+        let config = RateLimitConfig {
+            requests_per_second: 1,
+            burst_size: 3,
+        };
+        let limiter = Arc::new(RateLimiter::new(config));
+        *limiter_opt = Some(Arc::clone(&limiter));
+        limiter
+    }
+}
+```
+
+`consumer_id` is never threaded through.
+
+## See Also
+
+- Issue (filed by Cycle 11 with link back to this spec)
+- `tap-mcp-bridge/src/security/rate_limit.rs` — the underlying `RateLimiter` primitive (per-bucket, not per-key by design)
+- Cycle 9 single-consumer harness `.local/testing/scratch/src/rate_limit_drive.rs` — never noticed the multi-consumer issue because it only tested with one consumer_id

--- a/specs/004-id-fields-path-traversal/spec.md
+++ b/specs/004-id-fields-path-traversal/spec.md
@@ -1,0 +1,207 @@
+# Spec 004 — id-fields embedded in URL paths via `format!()` enable path-traversal
+
+**Status**: Draft
+**Priority**: P1 (Bug — broken functionality on strict TAP merchants / security on loose merchants; systemic across 12+ tool functions)
+**Type**: Bug fix + input validation
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 13 live testing, master @ 10b919e
+**Source**: `.local/testing/scratch/src/adversarial_ids.rs`
+
+## Problem Statement
+
+Multiple MCP tool functions in `tap-mcp-bridge` accept caller-supplied `id`
+fields (`item_id`, `order_id`, `product_id`, `subscription_id`, `plan_id`,
+etc.) and embed them verbatim into URL paths via `format!()`, with **no
+input validation and no percent-encoding of path-segment-special characters**.
+
+When a caller supplies an id containing `..` segments (e.g.
+`item_id="../../admin"`), the resulting path:
+
+1. The bridge constructs `path = "/cart/items/../../admin"` and passes it to
+   `signer.sign_request(method, authority, path, ...)`. The Ed25519 signature
+   covers `/cart/items/../../admin` as the `@path` derived component.
+2. `compose_request_url` (`tap-mcp-bridge/src/mcp/http.rs:57–64`) does
+   **no path normalization** — it simply concatenates the base URL string
+   with `path`.
+3. When `reqwest` actually issues the request, its internal `url::Url`
+   parser **does** normalize `..` segments. The wire path therefore
+   becomes `/admin`.
+
+Two failure modes follow:
+
+- **TAP-strict merchant** (RFC 9421 §2.2.6 conformant): reconstructs
+  `@path` from the wire request → `/admin`. Compares to signed `@path`
+  → `/cart/items/../../admin`. Mismatch ⇒ **signature verification fails
+  ⇒ legitimate cart-item-update requests are rejected** whenever the
+  `item_id` happens to contain `..` segments (even by accident, e.g.
+  merchant-issued ids that happen to contain `..`).
+- **TAP-loose merchant** (does not strictly verify `@path`, or accepts
+  the signed form): receives a request bound for `/admin` (or any
+  arbitrary endpoint the attacker constructs). **Privilege escalation**:
+  a malicious MCP client controlling `item_id` can target any merchant
+  endpoint reachable from the same host, with a valid Ed25519 signature
+  from the bridge's registered agent identity.
+
+Affected functions (all use `format!("/.../{id}", ...)` for path
+construction):
+
+| Function | id field | Path template |
+|---|---|---|
+| `update_cart_item` | `item_id` | `/cart/items/{item_id}` |
+| `remove_from_cart` | `item_id` | `/cart/items/{item_id}` |
+| `get_product` | `product_id` | `/products/{product_id}` |
+| `get_order` | `order_id` | `/orders/{order_id}` |
+| `get_subscription_plan` | `plan_id` | `/subscriptions/plans/{plan_id}` |
+| `get_subscription` | `subscription_id` | `/subscriptions/{subscription_id}` |
+| `update_subscription` | `subscription_id` | `/subscriptions/{subscription_id}` |
+| `cancel_subscription` | `subscription_id` | `/subscriptions/{subscription_id}/cancel` |
+| `pause_subscription` | `subscription_id` | `/subscriptions/{subscription_id}/pause` |
+| `resume_subscription` | `subscription_id` | `/subscriptions/{subscription_id}/resume` |
+| `report_usage` | `subscription_id` | `/subscriptions/{subscription_id}/usage` |
+| `get_usage` | `subscription_id` | `/subscriptions/{subscription_id}/usage/summary` |
+| `update_payment_method` | `subscription_id` | `/subscriptions/{subscription_id}/payment-method` |
+| `preview_proration` | `subscription_id` | `/subscriptions/{subscription_id}/proration-preview` |
+
+Confirmed live for `update_cart_item`, `get_order`, `get_product` in cycle
+13's `adversarial-ids` harness:
+
+```
+update_cart_item item_id='../../admin' → wire path "/admin"
+get_order order_id='../../admin'        → wire path "/admin"
+get_product product_id='../../secret'   → wire path "/secret"
+```
+
+The remaining 11 functions follow the same code pattern and are presumed
+to behave identically.
+
+## User Stories
+
+- **As a TAP-strict merchant** I expect that any signed request with a
+  valid Ed25519 signature and matching `@path` derived component
+  represents the agent's intent. The bridge breaking this invariant
+  silently means I reject otherwise-valid requests and the agent looks
+  buggy from my side.
+- **As a TAP-loose merchant** (or one that has admin endpoints reachable
+  from the same host as the cart endpoint) I am exposed to privilege
+  escalation if a malicious caller controls any of the id fields the
+  bridge passes through.
+- **As a bridge maintainer** I expect that the signed `@path` and the
+  wire `@path` are always identical — that is the RFC 9421 invariant
+  that makes signature verification meaningful. Currently it is broken
+  for any id containing `..`, `\\`, or other URL-path-special characters.
+- **As a security reviewer** I need user-controlled values that flow into
+  URL paths to either be rejected or percent-encoded — never embedded
+  verbatim. This is OWASP A1 / A4 territory.
+
+## Functional Requirements
+
+**FR-1**: All caller-supplied id fields routed through `format!("/.../{id}")`
+MUST either be:
+  - **(A)** validated at the tool entry point against a strict allowlist
+    (e.g. ASCII alphanumeric + hyphen + underscore, max 64 chars — same
+    constraint as `validate_consumer_id` and the existing typed
+    `SubscriptionId::new` / `PlanId::new`), with a clear `BridgeError`
+    on rejection; OR
+  - **(B)** percent-encoded as a single path segment via
+    `url::form_urlencoded` or equivalent, so `..`, `/`, `?`, `#`, `%`,
+    NUL, CRLF are encoded.
+
+Position A is preferred — the bridge already enforces a strict allowlist
+on `consumer_id` and on the typed wrapper constructors. The
+"plain `String`" id fields are an inconsistency.
+
+**FR-2**: `compose_request_url` MUST guarantee that signed `@path` ==
+wire `@path`. If validation/encoding does not happen at the tool entry
+point, `compose_request_url` should canonicalize the path (or refuse to
+proceed if `..` segments are present) so signature and wire stay in sync.
+
+**FR-3**: A regression test MUST exist for at least one id-field per
+distinct path pattern (`/cart/items/{}`, `/orders/{}`, `/products/{}`,
+`/subscriptions/{}`, `/subscriptions/{}/cancel`, etc.) asserting that:
+  - id values containing `..` are rejected at the tool entry point, OR
+  - if accepted, the wire path's segment count and structure match the
+    template (so `..` cannot collapse into `/admin`).
+
+**FR-4**: Documentation on each tool function's `# Errors` section MUST
+list the id-field constraints (ascii alphanumeric + hyphen + underscore,
+max length, etc.).
+
+## Non-Functional Requirements
+
+- **Performance**: validation is O(n) over each id; negligible.
+- **Backward compatibility**: pre-1.0 — breaking changes allowed.
+  Existing callers using strict ids (alphanumeric + hyphen + underscore)
+  are unaffected. Callers passing arbitrary strings will start receiving
+  validation errors — capture in CHANGELOG.
+- **Documentation**: CHANGELOG entry under [Unreleased] / Fixed
+  describing the path-traversal surface, the allowlist applied, and any
+  breaking-change implications for callers passing non-strict ids.
+- **Security**: this is a defense-in-depth issue. Even on TAP-strict
+  merchants, the bridge produces signature-invalid requests for some
+  inputs; on loose merchants it is a privilege-escalation surface.
+
+## Design Choices (Open Questions for /sdd plan)
+
+1. **Position A vs B**: validate at entry point (reject), or
+   percent-encode the segment (accept-and-encode)? The TAP spec does not
+   restrict id syntax; merchants are free to issue ids with arbitrary
+   characters. Position B preserves more flexibility but lets `..` /
+   `/` reach the merchant in encoded form, which a buggy merchant may
+   still misinterpret. Position A is conservative and matches the
+   existing `consumer_id` validator. Recommendation: **Position A** for
+   `update_cart_item`, `remove_from_cart`, `get_subscription_plan`,
+   `get_subscription`, all subscription mutators (`update`, `cancel`,
+   `pause`, `resume`, `report_usage`, `get_usage`,
+   `update_payment_method`, `preview_proration`), `get_order`, and
+   `get_product`. The typed `PlanId::new` and `SubscriptionId::new`
+   already enforce this — wrap the caller-supplied strings in those
+   types at the MCP entry point.
+2. **What about `consumer_id` in path segments?** None of the affected
+   functions put `consumer_id` in the path — it's always in the query
+   string. So `consumer_id`'s existing allowlist is sufficient.
+3. **`cart_id` in `get_cart`** routes through query string and is
+   correctly percent-encoded by `build_url_with_query`. Not affected.
+4. **Should `compose_request_url` reject `..` defensively?** Even with
+   FR-1 in place, a future code path that bypasses the tool layer (e.g.
+   tests, library users calling `execute_tap_request_with_acro`
+   directly) would still slip through. Adding `..` rejection to
+   `compose_request_url` is one-line defense-in-depth.
+
+[NEEDS CLARIFICATION: confirm with TAP spec authors whether merchant ids
+are required to be ASCII-safe, or whether the bridge should percent-encode
+to support arbitrary id syntax.]
+
+## Reproduction / Evidence
+
+`adversarial-ids` harness (`.local/testing/scratch/src/adversarial_ids.rs`)
+output, cycle 13:
+
+```
+=== adversarial-ids: probe id-field handling in URL paths ===
+
+--- 1. update_cart_item item_id="../../admin" ---
+  wire path: "/admin"
+  signed @path snippet: "/admin"
+[FAIL] path-traversal succeeded: original /cart/items/X became "/admin"
+
+--- 7. systemic path-traversal across id-fields ---
+[FAIL] get_order order_id='../../admin'      → wire path "/admin"  (path-traversal succeeded)
+[FAIL] get_product product_id='../../secret' → wire path "/secret" (path-traversal succeeded)
+```
+
+Source evidence:
+
+- `tap-mcp-bridge/src/mcp/cart.rs:259` — `format!("/cart/items/{}", params.item_id)`
+- `tap-mcp-bridge/src/mcp/cart.rs:307` — same for `remove_from_cart`
+- `tap-mcp-bridge/src/mcp/products.rs` — `format!("/products/{}", product_id)`
+- `tap-mcp-bridge/src/mcp/orders.rs` — `format!("/orders/{}", order_id)`
+- `tap-mcp-bridge/src/mcp/subscriptions/tools.rs:491,624,689,755,815,872,934,979,1044,1106` — 10 sites for subscriptions
+- `tap-mcp-bridge/src/mcp/http.rs:57–64` — `compose_request_url` does no normalization
+- `reqwest` internally uses `url::Url::parse`, which collapses `..` segments
+
+## See Also
+
+- Issue (filed by Cycle 13)
+- Spec 001 (`update_cart_item` and `remove_from_cart` silently dropped `cart_id`) — closed by #132. Different defect, same general theme: id-fields are insufficiently validated at the MCP entry point.
+- `validate_consumer_id` (`tap-mcp-bridge/src/mcp/tools.rs:380`) and `SubscriptionId::new` / `PlanId::new` (`tap-mcp-bridge/src/mcp/subscriptions/models.rs:29, 63`) — the existing constraint shape, unused at the relevant call sites.
+- RFC 9421 §2.2.6 — `@path` derived component definition.

--- a/specs/005-redirects-leak-tap-headers/spec.md
+++ b/specs/005-redirects-leak-tap-headers/spec.md
@@ -1,0 +1,187 @@
+# Spec 005 — HTTP redirects leak signed TAP headers and ACRO body to redirect target
+
+**Status**: Draft
+**Priority**: P1 (Bug — security exposure: signed credentials + PII forwarded to non-merchant hosts)
+**Type**: Bug fix (HTTP client configuration)
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 15 live testing, master @ 19bb549
+**Source**: `.local/testing/scratch/src/redirect_probe.rs`
+
+## Problem Statement
+
+None of the bridge's three `reqwest::Client::builder()` call sites set a
+`redirect()` policy. `reqwest`'s default is `Policy::limited(10)` — follow
+up to 10 redirects automatically. For 307/308 the original method and
+body are preserved; for 301/302/303 the method is downgraded to GET and
+the body is dropped. In **all** cases, only the four "sensitive" headers
+(`Authorization`, `Cookie`, `Proxy-Authorization`, `Cookie2`) are
+stripped on cross-host redirects. TAP-specific headers
+(`Signature`, `Signature-Input`, `Signature-Agent`, `Content-Digest`)
+are NOT in reqwest's strip list — they are forwarded verbatim.
+
+A malicious or compromised merchant (or DNS-spoofed merchant, or
+merchant under MITM) can therefore use a 30x response to redirect the
+agent to an attacker-controlled host and capture:
+
+- The Ed25519 `Signature` (proof of agent identity, bound to the
+  signed `@path`).
+- The signed components in `Signature-Input` (revealing the agent's
+  intent).
+- The agent's `Signature-Agent` directory URL.
+- The `Content-Digest` (binds the body to the signature).
+- For 307/308: the **full request body**.
+  - For ACRO requests: contains `country_code`, `zip`, `ip_address`,
+    `user_agent`, `platform` — PII tied to the consumer_id.
+  - For APC requests: contains the RSA-OAEP / AES-GCM encrypted
+    ciphertext (cannot be decrypted by the attacker without the
+    merchant's private RSA key, but timing/size/replay correlation
+    possible).
+
+The defect is **systemic** across all three HTTP clients in the
+workspace:
+
+| Client | File | Used by |
+|---|---|---|
+| `create_http_client()` | `tap-mcp-bridge/src/mcp/http.rs:76-83` | every e-commerce tool (browse, checkout, products, cart, orders, payment) |
+| `SUBSCRIPTION_HTTP_CLIENT` | `tap-mcp-bridge/src/mcp/subscriptions/tools.rs:33-40` | every subscription tool |
+| `DEFAULT_HTTP_CLIENT` | `tap-mcp-bridge/src/transport/http/mod.rs:23-30` | the public `transport::http::HttpTransport` |
+
+## User Stories
+
+- **As a TAP agent operator** I expect that signed credentials are sent
+  ONLY to the registered merchant. If the merchant returns a 30x, that
+  is either a misconfiguration (which I want to surface as an error) or
+  a compromise attempt (which I want to refuse outright). Silently
+  forwarding the signature to a redirect target is neither.
+- **As a security reviewer** I expect signed credentials to be
+  point-to-point, not transitive across HTTP redirects. The TAP
+  protocol does not contemplate redirect-following at the agent layer;
+  any redirect handling should be a deliberate caller decision, not
+  silent reqwest default behavior.
+- **As a downstream library consumer** I expect that the bridge's
+  HTTP client is hardened against the cross-host header-leak class of
+  attacks. Authorization-style headers (which TAP signatures
+  effectively are) must not flow across host boundaries.
+
+## Functional Requirements
+
+**FR-1**: The three HTTP clients
+(`create_http_client`, `SUBSCRIPTION_HTTP_CLIENT`, `DEFAULT_HTTP_CLIENT`)
+MUST disable redirect following by default. The recommended
+configuration is `.redirect(reqwest::redirect::Policy::none())`. Any
+30x response from the merchant MUST surface as a `BridgeError` rather
+than be silently followed.
+
+**FR-2**: If a future feature requires redirect-aware behavior, it MUST
+use a custom `Policy::custom(...)` that:
+  - Requires the redirect target's host to match the signed `@authority`
+    (i.e. follow only same-host redirects).
+  - Strips all four TAP headers AND `Content-Digest` before re-issuing
+    the request.
+  - Re-signs the request with the new `@path` / `@authority` (since
+    the agent's intent has effectively changed — different URL is a
+    different request under RFC 9421).
+  - Bounds total hops more conservatively than the default 10.
+
+**FR-3**: A regression test MUST exist asserting that a merchant
+returning 307 to a different host produces a `BridgeError` and that
+no follow-up request is issued. The `redirect-probe` harness in
+`.local/testing/scratch/` already encodes this check.
+
+**FR-4**: The error message returned for a refused redirect MUST be
+distinguishable from generic transport errors so callers can implement
+their own redirect policy at a higher layer if their use case requires
+it.
+
+## Non-Functional Requirements
+
+- **Performance**: redirect-disabling is a one-line configuration with
+  no performance impact.
+- **Backward compatibility**: pre-1.0 — any caller currently relying
+  on the bridge auto-following 30x will start receiving errors. This
+  is a security-positive breaking change. CHANGELOG entry under
+  `[Unreleased] / Fixed` with an explicit "BREAKING" callout for
+  callers that depend on the old behavior.
+- **Documentation**: every `Client::builder()` call site needs an
+  inline comment documenting why redirect-following is disabled
+  (cross-reference RFC 9421 §1: signatures are bound to the request,
+  redirect = different request).
+- **Security**: this is a defense-in-depth addition. The bridge already
+  enforces HTTPS-only (modulo `TAP_ALLOW_LOOPBACK` for tests) and
+  rejects loopback hosts. Disabling redirect-following closes the gap
+  where a TAP-signed request can leave the merchant's authority.
+
+## Design Choices (Open Questions for /sdd plan)
+
+1. **Position A — `Policy::none()`**: refuse all redirects. Simplest,
+   most conservative. Recommended.
+2. **Position B — `Policy::custom()` with same-host check**: allow
+   redirects only if the new host equals the original. Useful if
+   merchants legitimately use redirects (e.g. `/checkout` → `/checkout/`
+   trailing-slash normalization, or HTTP-to-HTTPS upgrade — though
+   HTTP is already rejected by `parse_merchant_url`). Risk: fragile to
+   `vhost` setups, CDN tricks, or load balancer hostnames.
+3. **Position C — `Policy::custom()` that re-signs**: auto-detect a
+   safe redirect target, strip TAP headers, re-sign. Most flexible but
+   complex; agent identity flows through redirect chain which is hard
+   to reason about.
+
+[NEEDS CLARIFICATION: TAP spec position on agent following redirects.
+RFC 9421 §1 says signatures are bound to the request; redirect = new
+request → re-sign or refuse. The TAP draft probably defers to the
+RFC.]
+
+Recommendation: **Position A** (`Policy::none()`). If a real merchant
+emits 30x in normal operation, the operator can patch their merchant
+config or escalate via a feature request — that's a clearer signal than
+silent header leakage.
+
+## Reproduction / Evidence
+
+`redirect-probe` harness output, cycle 15:
+
+```
+[test-307]
+  merchant received: 1 request(s)
+  attacker received: 1 request(s)
+[!] redirect WAS followed — checking what leaked to attacker
+    Path on attacker side:        /admin/exfil
+    Signature header forwarded:   true
+    Signature-Input forwarded:    true
+    Signature-Agent forwarded:    true
+    Content-Digest forwarded:     true
+    Body size at attacker:        766 bytes
+    Body carries ACRO PII fields: true
+
+[test-302]
+    Signature header forwarded: true
+
+[test-chain]
+  merchant served 11 requests in the chain
+[ok] redirect chain bounded (11≤11)
+  result: Err — TooManyRedirects
+```
+
+Source evidence:
+
+- `tap-mcp-bridge/src/mcp/http.rs:76-83` — `create_http_client()`,
+  no `.redirect(...)` configured
+- `tap-mcp-bridge/src/mcp/subscriptions/tools.rs:33-40` —
+  `SUBSCRIPTION_HTTP_CLIENT`, no `.redirect(...)` configured
+- `tap-mcp-bridge/src/transport/http/mod.rs:23-30` —
+  `DEFAULT_HTTP_CLIENT`, no `.redirect(...)` configured
+
+`reqwest` default `Policy::limited(10)` follows up to 10 redirects;
+TAP-specific headers (`Signature`, `Signature-Input`, `Signature-Agent`,
+`Content-Digest`) are not in reqwest's auto-strip list (only
+`Authorization`, `Cookie`, `Proxy-Authorization`, `Cookie2`).
+
+## See Also
+
+- Issue (filed by Cycle 15)
+- Spec 004 (path-traversal in id-fields) — different defect, same
+  general theme: the bridge's HTTP layer needs hardening against
+  attacker-controlled inputs.
+- RFC 9421 §1 — HTTP Message Signatures bind a signature to a specific
+  request; redirected requests are different requests.
+- reqwest docs on `redirect::Policy` — sensitive-header strip list.

--- a/specs/006-incomplete-redirect-fix/spec.md
+++ b/specs/006-incomplete-redirect-fix/spec.md
@@ -1,0 +1,151 @@
+# Spec 006 — #145 missed `mcp::tools::HTTP_CLIENT`; redirect leak persists for `browse_merchant` and `checkout_with_tap`
+
+**Status**: Draft
+**Priority**: P1 (Bug — same security exposure as #144 still active for two MCP tools)
+**Type**: Bug fix (one-line addition)
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 16 live testing, master @ 035e635
+**Source**: `.local/testing/scratch/src/redirect_probe.rs` (cycle 15 harness, re-run cycle 16)
+
+## Problem Statement
+
+PR #145 (closes #144) added
+`.redirect(reqwest::redirect::Policy::none())` to four
+`reqwest::Client::builder()` call sites:
+
+- `tap-mcp-bridge/src/mcp/http.rs:86` (`create_http_client`)
+- `tap-mcp-bridge/src/mcp/subscriptions/tools.rs:38` (`SUBSCRIPTION_HTTP_CLIENT`)
+- `tap-mcp-bridge/src/transport/http/mod.rs:28` (`DEFAULT_HTTP_CLIENT`)
+- `tap-mcp-bridge/src/transport/http/mod.rs:175` (`HttpTransport::with_config`)
+
+A **fifth** call site was missed: `tap-mcp-bridge/src/mcp/tools.rs:37`,
+the `HTTP_CLIENT: LazyLock<Client>` static that backs the private
+`execute_tap_request_with_acro` helper inside `mcp::tools`. This helper
+is called from `checkout_with_tap` (line 164) and `browse_merchant`
+(line 234) — the **two original e-commerce MCP tools** registered in
+`tap-mcp-server`.
+
+As a result, `tools/call browse_merchant` and `tools/call checkout_with_tap`
+through the MCP server still:
+
+- Follow merchant 30x responses (up to reqwest's default `Policy::limited(10)`).
+- Forward all four TAP signature headers (`Signature`, `Signature-Input`,
+  `Signature-Agent`, `Content-Digest`) to the redirect target.
+- For 307/308: forward the unencrypted ACRO body (consumer PII:
+  `country_code`, `zip`, `ip_address`, `user_agent`, `platform`)
+  to the redirect target.
+
+The attack surface from #144 is unchanged for these two tools. The
+other 12 MCP tools (the e-commerce expansion in #125 and the 12
+subscription functions) ARE fixed because they go through `mcp::http`
+or `mcp::subscriptions::tools` clients — both correctly patched.
+
+## User Stories
+
+- **As a TAP agent operator** I expect that when an upstream PR closes
+  a security issue, the fix covers all relevant code paths, not a
+  subset. The CHANGELOG entry for #145 says "all reqwest clients" but
+  one was missed.
+- **As a security reviewer** I expect a `grep -rn 'Client::builder()'`
+  to be part of the verification of any redirect-policy fix. Cycle 16's
+  re-run of `redirect-probe` immediately surfaced the gap.
+
+## Functional Requirements
+
+**FR-1**: Add `.redirect(reqwest::redirect::Policy::none())` to the
+`Client::builder()` chain at `tap-mcp-bridge/src/mcp/tools.rs:37`.
+The chain currently reads:
+
+```rust
+Client::builder()
+    .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+    .pool_max_idle_per_host(100)
+    .http2_prior_knowledge()
+    .build()
+    .expect("failed to create HTTP client")
+```
+
+Insert `.redirect(reqwest::redirect::Policy::none())` before `.build()`.
+
+**FR-2**: A regression test MUST exist in `mcp/tools.rs` (or its `mod
+tests`) asserting that `HTTP_CLIENT` does not follow redirects, mirroring
+the existing `test_create_http_client_does_not_follow_redirects` in
+`mcp/http.rs:372`. Without this test, the next refactor that adds yet
+another client constructor risks the same omission.
+
+**FR-3**: Update `regressions.md` permanent gates to require all 5+
+`Client::builder()` call sites to call `.redirect(...)` — the live
+tester should `grep -rn 'Client::builder()' tap-mcp-bridge/src/ |
+xargs grep -L 'redirect'` after any HTTP-client touching PR. Currently
+this is encoded in `redirect-probe`, which exercises the
+`browse_merchant` path; if the harness ever stops covering this exact
+path, the gap returns.
+
+## Non-Functional Requirements
+
+- **Performance**: zero impact (same as #145).
+- **Backward compatibility**: matches the security-positive breaking
+  change introduced in #145 — `tools/call browse_merchant` and
+  `tools/call checkout_with_tap` will start refusing 30x responses.
+  CHANGELOG entry under `[Unreleased] / Fixed` referencing both #144
+  and the follow-up.
+- **Documentation**: copy the doc-comment from
+  `mcp::http::create_http_client` (lines 65-91) onto the
+  `HTTP_CLIENT` static so the rationale is visible at the
+  declaration site.
+
+## Reproduction / Evidence
+
+`cargo run --bin redirect-probe` after pulling master @ `035e635`:
+
+```
+[test-307]
+  merchant received: 1 request(s)
+  attacker received: 1 request(s)
+[!] redirect WAS followed — checking what leaked to attacker
+    Path on attacker side:        /admin/exfil
+    Signature header forwarded:   true
+    Signature-Input forwarded:    true
+    Signature-Agent forwarded:    true
+    Content-Digest forwarded:     true
+    Body size at attacker:        766 bytes
+    Body carries ACRO PII fields: true
+
+[test-302]
+    Signature header forwarded: true
+```
+
+Source evidence:
+
+```
+$ grep -rn 'Client::builder()' tap-mcp-bridge/src/
+tap-mcp-bridge/src/transport/http/mod.rs:28:    Client::builder()       # has redirect(none) ✓
+tap-mcp-bridge/src/transport/http/mod.rs:175:        let mut builder = Client::builder()  # has redirect(none) ✓
+tap-mcp-bridge/src/mcp/tools.rs:37:    Client::builder()                # MISSED ✗
+tap-mcp-bridge/src/mcp/http.rs:86:    Client::builder()                 # has redirect(none) ✓
+tap-mcp-bridge/src/mcp/subscriptions/tools.rs:38:    Client::builder()  # has redirect(none) ✓
+```
+
+`mcp/tools.rs` HTTP_CLIENT chain (lines 36-43) does not call `.redirect(...)`:
+
+```rust
+static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .pool_max_idle_per_host(100)
+        .http2_prior_knowledge()
+        .build()
+        .expect("failed to create HTTP client")
+});
+```
+
+`browse_merchant` (line 217) → `execute_tap_request_with_acro` (line 234) →
+private function at line 258 → `HTTP_CLIENT` (line 290).
+
+`checkout_with_tap` (line 142) → same path through line 164 → 290.
+
+## See Also
+
+- Issue (filed by Cycle 16)
+- #144 (parent issue) and #145 (incomplete fix) — context for why this is a follow-up.
+- Spec 005 — the original spec, all FRs still apply with this fifth call site added.

--- a/specs/007-weak-signing-keys-accepted/spec.md
+++ b/specs/007-weak-signing-keys-accepted/spec.md
@@ -1,0 +1,160 @@
+# Spec 007 — `TAP_SIGNING_KEY` validator accepts all-zero / all-ones / low-entropy seeds
+
+**Status**: Draft
+**Priority**: P2 (Bug — operational hazard: operator misconfiguration leads to silent impersonation surface)
+**Type**: Bug fix (input validation hardening)
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 18 live testing, master @ f61b61e
+**Source**: `.local/testing/debug/cycle18/probe_env.sh`
+
+## Problem Statement
+
+`tap-mcp-server`'s `validate_signing_key` (`tap-mcp-server/src/main.rs:149`)
+checks two things and only two: that the input is exactly 64 hex
+characters, and that every character is in `[0-9a-fA-F]`. Any 32-byte
+seed that satisfies these constraints is accepted, including:
+
+- All zeros (`0000...0000`, 64 × `0`).
+- All ones (`ffff...ffff`, 64 × `f`).
+- Any other low-entropy seed an operator might type as a placeholder
+  (`0123...` repeating, `cafebabe...`, etc.).
+
+Ed25519 derives the keypair from the seed by hashing it with SHA-512
+and clamping the result, so even pathological seeds produce a valid
+signing key. The all-zero seed produces a publicly-known, reproducible
+keypair — anyone who happens to use the same all-zero seed signs
+identically.
+
+A common operator mistake: copy-pasting a placeholder value from docs
+or examples (`TAP_SIGNING_KEY="0000...0000"`), or running
+`TAP_SIGNING_KEY=$(printf '0%.0s' {1..64})` instead of
+`TAP_SIGNING_KEY=$(openssl rand -hex 32)`. The bridge accepts the value,
+runs the server, and silently signs every TAP request with a key that
+has no entropy.
+
+This is a **defense-in-depth gap**: the validator catches obvious
+malformed input (wrong length, non-hex chars) but not the catastrophic
+operator-mistake case where a placeholder seed makes it into
+production.
+
+## User Stories
+
+- **As a TAP agent operator** I expect the bridge to refuse to start
+  with a key that has no entropy, so a copy-paste placeholder doesn't
+  silently end up in production. SSH and TLS tooling have refused
+  trivially-weak keys for years; the bridge should follow suit.
+- **As a security reviewer** I expect Ed25519 key validation to include
+  at least a "not all zeros / not all ones" check. Anything more
+  sophisticated (NIST SP 800-22, randomness tests) is overkill for a
+  validator running once at startup, but the trivial cases must be
+  rejected.
+
+## Functional Requirements
+
+**FR-1**: `validate_signing_key` MUST reject inputs whose decoded 32
+bytes are entirely composed of `0x00` or entirely composed of `0xff`.
+Error message MUST mention that the seed appears to have no entropy
+and reference `openssl rand -hex 32` as the suggested generator.
+
+**FR-2**: `validate_signing_key` SHOULD warn (or reject, depending on
+appetite) when the decoded seed has obvious low-entropy patterns:
+  - All bytes equal (e.g. all `0x55`, all `0xaa`).
+  - Sequential bytes (e.g. `00 01 02 03 ... 1f`).
+  - Repeating short pattern (e.g. `de ad be ef de ad be ef ...`).
+
+The simplest practical implementation is to compute the Shannon
+entropy of the 32-byte seed and reject anything below a threshold
+(e.g. 4.5 bits/byte). The Shannon-entropy check rejects the all-zero
+and all-ones cases naturally without enumerating them.
+
+**FR-3**: A regression test in `tap-mcp-server::tests` MUST cover at
+least:
+  - All-zero seed → rejected.
+  - All-ones seed → rejected.
+  - All-bytes-equal seed (e.g. all `0xab`) → rejected.
+  - Properly random seed (32 random bytes from a known fixture) → accepted.
+
+**FR-4**: CHANGELOG entry under `[Unreleased] / Fixed` describing the
+hardening, with explicit "BREAKING" callout for any operator currently
+running with a weak placeholder seed (which would now refuse to start
+— security-positive).
+
+## Non-Functional Requirements
+
+- **Performance**: validation is O(1) over the 32-byte seed; one-time
+  startup cost. Negligible.
+- **Backward compatibility**: pre-1.0 — operators currently running
+  with a weak placeholder will see a startup failure. Security-positive
+  breaking change.
+- **Documentation**: the doc-comment on the `signing_key_hex` field
+  and the env-var doc at the top of `main.rs` should mention the
+  entropy requirement and reference `openssl rand -hex 32`.
+
+## Design Choices (Open Questions for /sdd plan)
+
+1. **Position A — "trivial weak" only**: reject all-zero and all-ones,
+   nothing else. Cheapest fix, covers 90% of the operator-mistake
+   surface. Recommended starting point.
+2. **Position B — Shannon entropy threshold**: compute Shannon entropy
+   of the 32-byte seed and reject below threshold. Catches more
+   patterns including all-bytes-equal-to-X for any X. Slightly more
+   complex; threshold tuning could be over-aggressive (a poorly-RNG-d
+   seed might trip it).
+3. **Position C — NIST SP 800-22 lite**: a few of the simpler NIST
+   randomness tests (frequency, runs, cumulative sums). Overkill for
+   a one-shot validator and risks false positives on legitimate keys.
+
+Recommendation: **Position A** for v0.x. Position B as a follow-up if
+the project ships a security-conscious release later.
+
+[NEEDS CLARIFICATION: TAP spec position on agent key entropy. RFC
+specifies "use of cryptographically secure random number generators";
+whether the bridge should enforce post-hoc on operator-provided values
+is a deployment-time concern.]
+
+## Reproduction / Evidence
+
+`probe_env.sh` (cycle 18) output, relevant lines:
+
+```
+=== TAP_SIGNING_KEY validator probes ===
+KEY_valid                                          | STARTED  ✓
+KEY_all_zeros                                      | STARTED  ✓
+KEY_all_ones                                       | STARTED  ✓
+KEY_63chars                                        | rejected
+KEY_65chars                                        | rejected
+KEY_with_spaces                                    | rejected
+KEY_uppercase_OK                                   | STARTED  ✓
+KEY_unicode                                        | rejected
+KEY_mixed_nonhex                                   | rejected
+```
+
+Note: `KEY_uppercase_OK` accepting hex case-insensitive is correct
+(the existing length + alphabet checks). The defect is specifically
+the `KEY_all_zeros` / `KEY_all_ones` rows.
+
+Source evidence — `tap-mcp-server/src/main.rs:149-162`:
+
+```rust
+fn validate_signing_key(key_hex: &str) -> Result<()> {
+    if key_hex.len() != 64 { ... }                    // length only
+    if !key_hex.chars().all(|c| c.is_ascii_hexdigit()) { ... }   // alphabet only
+    Ok(())                                            // no entropy check
+}
+```
+
+Public Ed25519 key derived from the all-zero seed:
+`3b6a27bcceb6a42d62a3a8d02a6f0d73653215771de243a63ac048a18b59da29`. This
+is a publicly-known constant; anyone who happens to also use the
+all-zero seed gets the same keypair.
+
+## See Also
+
+- Issue (filed by Cycle 18)
+- Spec 003 (`process_payment_rate_limited` per-consumer scope) — same
+  general theme: validators that enforce some constraints but miss
+  obvious operator-mistake cases.
+- Cycle 18 also surfaced TAP_AGENT_DIRECTORY validator gaps (loopback
+  hosts, userinfo URLs, port 0, path-traversal segments). Those are
+  filed separately as P3 enhancement since they're operator-config
+  quality issues, not security operational hazards.

--- a/specs/008-replay-cache-lru-eviction/spec.md
+++ b/specs/008-replay-cache-lru-eviction/spec.md
@@ -1,0 +1,165 @@
+# Spec 008 — `TapVerifier`'s LRU eviction creates a replay-protection bypass
+
+**Status**: Draft
+**Priority**: P2 (Bug — replay protection has a knowable bypass; security-relevant, downstream-consumer impact)
+**Type**: Bug fix (architecture: eviction policy)
+**Owner**: TBD
+**Discovered**: 2026-05-01, Cycle 20 live testing, master @ f61b61e
+**Source**: `.local/testing/scratch/src/replay_cache_eviction.rs`
+
+## Problem Statement
+
+`TapVerifier` (`tap-mcp-bridge/src/tap/verifier.rs`) uses
+`Arc<Mutex<LruCache<nonce_string, expires_secs>>>` for replay protection.
+The `verify_request` flow:
+
+1. Lock the cache.
+2. If `nonce` is in the cache with non-expired `cached_expires`, return
+   `BridgeError::ReplayAttack`.
+3. Otherwise, insert `(nonce, expires)`.
+
+The cache is bounded — `LruCache::new(capacity)` — and uses **LRU
+eviction**: when capacity is reached, the least-recently-used entry is
+evicted regardless of whether its `expires` has passed.
+
+This creates a **knowable bypass**: an attacker who can cause the
+verifier to process `capacity + 1` distinct nonces within the original
+signature's `expires` window (max 8 minutes per TAP §2.3) evicts the
+legitimate nonce, then replays the captured request:
+
+- Cache lookup misses (entry was evicted).
+- Timestamp check passes (`now <= expires`).
+- The cached-expires-vs-now check at line 148-156 never fires because
+  the entry is gone.
+- Replay accepted as fresh.
+
+For default capacity `10_000`, an attacker needs to flood >10k distinct
+nonces in 8 min ≈ 21 RPS sustained. Feasible for any well-resourced
+attacker. Capacity is not part of the public API documentation, so
+downstream consumers may use smaller values without realising the
+window-of-vulnerability is correspondingly smaller.
+
+`TapVerifier` is a `pub` re-export from `tap_mcp_bridge::tap`. Merchants
+or middleware using this crate as their TAP verifier are exposed.
+`tap-mcp-server` itself doesn't verify signatures (it's the agent
+side), so the bridge's own runtime is not directly affected.
+
+## User Stories
+
+- **As a merchant operator** using `tap-mcp-bridge::TapVerifier` for
+  replay protection, I expect signatures within their `expires` window
+  to be detected as replays even when the verifier is under load. The
+  current LRU policy means a noisy peer (or a flood attacker) silently
+  shortens my replay-protection window from the documented "until
+  expires" down to "until cache rotates".
+- **As a security reviewer** I expect replay-protection eviction to be
+  TTL-driven (entries leave the cache when they're no longer needed),
+  not LRU-driven (entries leave when something else is more recently
+  used). LRU is the wrong policy class for security-state.
+
+## Functional Requirements
+
+**FR-1**: Replace LRU eviction with TTL-driven eviction. Entries leave
+the cache when their `expires` (plus `CLOCK_SKEW_TOLERANCE_SECS`)
+passes. The cache is bounded by `max_validity_window × max_concurrent_RPS`
+worth of entries — finite and predictable.
+
+**FR-2**: If a hard memory cap is required, fail-closed when the cache
+is full: return a non-replay error (e.g. `BridgeError::CryptoError(
+"verifier overloaded; refusing fresh signatures")` ) rather than evict
+a still-valid entry. Operationally this surfaces as a backpressure
+signal.
+
+**FR-3**: A regression test in `tap-mcp-bridge::tap::verifier::tests`
+must assert that a fresh-but-evicted nonce is detected as replay. The
+test is exactly the cycle-20 probe shape: tiny capacity, sign,
+flood-with-distinct-nonces, replay original.
+
+**FR-4**: `TapVerifier::new` documentation must explicitly describe
+the eviction policy and what guarantees the chosen `capacity` provides
+under flood conditions.
+
+## Non-Functional Requirements
+
+- **Performance**: TTL-driven eviction can be O(log N) using a
+  BTreeMap ordered by expires, plus a HashMap nonce → key. LRU's
+  amortised O(1) is replaced by O(log N), but TTL cleanup runs only
+  when entries actually need to leave.
+- **Memory**: bounded by `max_validity_window × peak_RPS`. For TAP's
+  8-min window and 100 RPS that's 48k entries — comparable to the
+  current 10k LRU capacity.
+- **Backward compatibility**: pre-1.0 — `TapVerifier::new(capacity)`
+  signature can stay the same, but the parameter's semantics shift
+  from "max entries before LRU evicts" to "max entries before
+  fail-closed kicks in" (FR-2 path) or "advisory hint, ignored if
+  TTL-driven" (FR-1 pure form).
+- **Documentation**: CHANGELOG entry under `[Unreleased] / Security`
+  describing the bypass and the mitigation.
+
+## Design Choices (Open Questions for /sdd plan)
+
+1. **Position A — TTL-only with no hard cap**: simplest, memory is
+   bounded by validity-window × peak-RPS. Risk: under unbounded
+   adversarial flood, memory grows linearly until expires fires.
+   Acceptable if the application has its own rate-limiting layer
+   upstream of the verifier.
+2. **Position B — TTL-primary, hard cap fail-closed**: TTL-driven
+   eviction in normal operation; if a hard cap is hit, refuse new
+   signatures (return error). Operator-visible backpressure signal.
+3. **Position C — LRU + TTL hybrid (deletion priority)**: maintain
+   LRU for performance, but BEFORE evicting check if the LRU-victim's
+   `expires` is still in the future — if so, fail-closed instead of
+   evicting. More code, but preserves O(1) hot path.
+
+Recommendation: **Position B** — TTL-primary with a configurable
+hard cap. The hard cap protects against pathological memory growth,
+the TTL protects against the LRU-bypass.
+
+[NEEDS CLARIFICATION: TAP/RFC 9421 position on verifier-side replay
+protection guarantees. RFC 9421 §2.5 says verifiers SHOULD maintain a
+cache of recent nonces — doesn't specify eviction policy. The TAP
+draft probably defers to RFC. So the choice is implementation-side.]
+
+## Reproduction / Evidence
+
+Cycle 20 `replay-cache-eviction` harness output:
+
+```
+=== replay-cache-eviction: LRU eviction creates a replay window? ===
+
+[step 1] sign legitimate request → verify (should be Ok)
+  legitimate verify: Ok ✓
+
+[step 2] immediate replay (cache hit) → must be ReplayAttack
+  ReplayAttack ✓
+
+[step 3] flood verifier with 8 distinct fresh nonces → evict N1 by LRU
+  8 distinct fresh nonces all verified ✓
+
+[step 4] replay original N1 signature post-eviction → ?
+[FAIL] POST-EVICTION REPLAY ACCEPTED AS Ok — bridge has a knowable
+       replay-protection bypass via LRU flooding
+```
+
+Source evidence — `tap-mcp-bridge/src/tap/verifier.rs`:
+
+- Line 30: `nonce_cache: Arc<Mutex<LruCache<String, u64>>>`
+- Line 48: `Self { nonce_cache: Arc::new(Mutex::new(LruCache::new(cap))) }`
+- Lines 142-160: replay check; if cache lookup misses (because LRU
+  evicted), `pop` doesn't run and the nonce is unconditionally
+  re-inserted.
+
+The probe uses capacity = 8 for observability; the same dynamic plays
+out at any capacity once the attacker can flood `capacity + 1` distinct
+nonces within the validity window.
+
+## See Also
+
+- Issue (filed by Cycle 20)
+- RFC 9421 §2.5 — verifier MAY maintain a cache of nonces (silent on
+  eviction policy)
+- TAP spec §3.x (validity window, max 8 minutes)
+- `lru` crate (used as backing store; the issue is policy choice, not
+  crate behaviour)
+- Cycle 3 (`reliability-drive` harness): tested LRU + replay with
+  *sequential* access only; missed the eviction-under-flood window.

--- a/specs/009-rsa-pss-signing-support/spec.md
+++ b/specs/009-rsa-pss-signing-support/spec.md
@@ -1,0 +1,216 @@
+# Spec 009 — `tap-mcp-bridge` signs exclusively with Ed25519; official TAP reference agent also supports RSA-PSS-SHA256
+
+**Status**: Draft
+**Priority**: P2 (Research / parity gap — interoperability risk with RSA-only merchants, not a defect in current behavior)
+**Type**: Research finding — algorithm parity gap
+**Owner**: TBD
+**Discovered**: Cycle 26, 2026-08-08
+**Source**: Research comparison against https://github.com/visa/trusted-agent-protocol (`tap-agent/` reference implementation README)
+
+## Problem Statement
+
+`tap-mcp-bridge`'s TAP signing implementation hardcodes the RFC 9421
+signature algorithm to Ed25519. The `alg` field is a string literal,
+not a configurable or pluggable value:
+
+- `tap-mcp-bridge/src/tap/acro.rs:185` — `alg: "ed25519".to_owned()`
+  inside `Acro` construction (also documented as "always ed25519" at
+  `acro.rs:122`).
+- `tap-mcp-bridge/src/tap/apc.rs:195` — same pattern for `Apc`
+  (documented as "always ed25519" at `apc.rs:146`).
+- `tap-mcp-bridge/src/tap/signer.rs:150-151` and `:430-431` — the
+  `Signature-Input` header is built with a literal
+  `alg="ed25519"` component.
+- `tap-mcp-bridge/src/tap/jwk.rs` — the JWK representation is
+  hardcoded to `kty: "OKP"`, `crv: "Ed25519"` (an Octet Key Pair JWK);
+  there is no `kty: "RSA"` path.
+- `tap-mcp-bridge/Cargo.toml:26` — only `ed25519-dalek` is a signing
+  dependency; no RSA crate (`rsa`, `ring`, or similar) is present.
+- No `SigningAlgorithm` enum, trait abstraction, or algorithm
+  selection point exists anywhere under `tap-mcp-bridge/src/tap/`.
+
+Visa's official reference implementation at
+[visa/trusted-agent-protocol](https://github.com/visa/trusted-agent-protocol)
+(the `tap-agent/` Streamlit reference agent) documents support for two
+RFC 9421-compatible signing algorithms:
+
+- **Ed25519** — recommended, modern, fast (this bridge's only path today).
+- **RSA-PSS-SHA256** — traditional RSA with PSS padding and SHA-256,
+  used by merchants whose key-management infrastructure is RSA-based
+  (e.g. existing HSM/PKI deployments that predate widespread Ed25519
+  adoption).
+
+`tap-mcp-bridge` exists specifically to let AI agents interoperate
+with TAP-conformant merchants. Because the reference implementation —
+the interoperability baseline for the whole protocol ecosystem —
+treats RSA-PSS-SHA256 as a first-class algorithm choice, any merchant
+that only accepts RSA-PSS-SHA256 signatures (by policy, compliance
+requirement, or existing key infrastructure) **cannot transact through
+this bridge at all**. This is a genuine interoperability gap, not a
+cosmetic omission: the bridge's entire purpose is broad merchant
+compatibility, and the current implementation silently narrows that to
+"merchants that accept Ed25519."
+
+This spec captures **what** the gap is and **why** it matters. It
+deliberately does not prescribe an implementation (crate choice, key
+storage format, negotiation protocol) — that belongs to `/sdd plan`.
+
+## User Stories
+
+### US-1: Merchant that only accepts RSA-PSS-SHA256
+
+AS A merchant operator running a TAP-conformant backend that only
+verifies RSA-PSS-SHA256 signatures (e.g. because their HSM/PKI
+infrastructure issues RSA keys and cannot mint Ed25519 keys)
+I WANT an agent using `tap-mcp-bridge` to be able to sign TAP requests
+with RSA-PSS-SHA256
+SO THAT agents built on this bridge can complete checkout flows against
+my storefront without me having to add Ed25519 key support first.
+
+**Acceptance criteria:**
+```
+GIVEN a merchant backend configured to verify RFC 9421 signatures
+      using RSA-PSS-SHA256 only
+WHEN an agent operator configures tap-mcp-bridge with an RSA signing
+     key and the matching algorithm selection
+THEN the bridge produces an ACRO/APC payload and Signature-Input
+     header with alg="rsa-pss-sha256", and the merchant's verifier
+     accepts the request
+```
+
+### US-2: Agent operator wanting broader merchant compatibility
+
+AS A TAP agent operator deploying `tap-mcp-server` across multiple
+merchants
+I WANT to choose the signing algorithm per deployment (Ed25519 or
+RSA-PSS-SHA256) via configuration, without forking the bridge
+SO THAT I can target the widest possible set of TAP-conformant
+merchants with a single codebase, matching what the official
+reference agent already offers.
+
+**Acceptance criteria:**
+```
+GIVEN an operator configuring TAP_SIGNING_KEY (or equivalent) for
+      tap-mcp-server
+WHEN the operator supplies an RSA private key and selects
+     RSA-PSS-SHA256 as the algorithm
+THEN the server starts successfully, signs all outbound TAP requests
+     with RSA-PSS-SHA256, and Ed25519-only deployments remain
+     unaffected (no behavior change for existing Ed25519 users)
+```
+
+## Functional Requirements
+
+**FR-1**: The signing algorithm MUST become a selectable/pluggable
+property rather than a hardcoded literal. `Acro::alg`, `Apc::alg`, and
+the `Signature-Input` header's `alg` parameter MUST reflect the
+algorithm actually used to produce the signature, not a fixed string.
+
+**FR-2**: The bridge MUST support signing RFC 9421 message signatures
+with RSA-PSS-SHA256 (RSASSA-PSS using SHA-256, per RFC 9421 §3.3.6 /
+the `rsa-pss-sha256` registered algorithm identifier), in addition to
+the existing Ed25519 (`ed25519`) path.
+
+**FR-3**: RSA key material MUST be loadable through a mechanism
+consistent with the project's existing key-handling conventions (e.g.
+`TAP_SIGNING_KEY`-style configuration in `tap-mcp-server`, or an
+equivalent explicit key-loading API in the library). Exact format
+(PEM, PKCS#8, raw modulus/exponent) is left to `/sdd plan`.
+
+**FR-4**: The JWK representation (`tap-mcp-bridge/src/tap/jwk.rs`)
+MUST be extended to represent RSA public keys (`kty: "RSA"` with `n`
+and `e` members per RFC 7518 §6.3.1) alongside the existing OKP/Ed25519
+representation, so that agent-directory publication and JWK
+thumbprinting (RFC 7638) work for both algorithms.
+
+**FR-5**: WHEN no algorithm is explicitly configured, THE SYSTEM SHALL
+default to Ed25519, preserving current behavior for all existing
+deployments (no breaking change for the default path).
+
+**FR-6**: WHEN an RSA key is configured, THE SYSTEM SHALL validate key
+strength (e.g. minimum modulus size — align with common TAP/PKI
+guidance, likely 2048-bit minimum, `[NEEDS CLARIFICATION: minimum RSA
+key size mandated or recommended by the TAP spec, if any]`) before
+accepting it, mirroring the existing weak-key rejection posture
+established for Ed25519 seeds (see Spec 007).
+
+**FR-7**: A regression test suite MUST cover RSA-PSS-SHA256 signing
+end-to-end: `Acro`/`Apc` construction with `alg: "rsa-pss-sha256"`,
+`Signature-Input` header construction, and signature verification
+against a known-good fixture (mirroring the existing Ed25519 test
+coverage in `acro.rs`, `apc.rs`, and `signer.rs`).
+
+**FR-8**: Both a library example (per this repo's convention of
+exercising critical paths through `tap-mcp-bridge/examples/`) and the
+`tap-mcp-server` MCP tool path MUST be able to exercise RSA-PSS-SHA256
+signing, consistent with the project's cross-interface-consistency
+requirement (`.claude/rules/continuous-improvement.md`).
+
+## Non-Functional Requirements
+
+- **Compatibility**: Adding RSA-PSS-SHA256 support MUST NOT change the
+  wire format, default algorithm, or public API behavior for existing
+  Ed25519-only callers. This is an additive capability.
+- **Crypto library choice**: `[NEEDS CLARIFICATION: which RSA crate —
+  `rsa` (pure Rust, RustCrypto), `ring`, or an OpenSSL binding — best
+  fits this project's existing dependency posture (`ed25519-dalek`,
+  workspace `deny.toml` license/advisory constraints)? This is a
+  `/sdd plan` decision but flagged here since it affects feasibility.]`
+- **Performance**: RSA-PSS-SHA256 signing/verification is
+  computationally heavier than Ed25519 (larger keys, modular
+  exponentiation vs. elliptic-curve operations). The chosen
+  implementation should not introduce unbounded latency in the
+  checkout hot path; benchmark against existing Ed25519 signing
+  latency once implemented.
+- **Key management**: RSA private keys are larger and have more
+  encoding variants (PKCS#1 vs PKCS#8, DER vs PEM) than the raw 32-byte
+  Ed25519 seed currently accepted via `TAP_SIGNING_KEY`. The configured
+  loading mechanism must not weaken the "secrets never in this repo's
+  dev workflow, resolved via the Zeph age vault" convention.
+- **Security**: RSA-PSS-SHA256 must use a cryptographically secure
+  salt length and SHA-256 as both hash and MGF1 hash, per RFC 9421
+  §3.3.6, to avoid downgrade or malleability issues. No custom padding
+  scheme.
+- **No regression to Ed25519 default path**: existing test suites,
+  examples, and merchant TOML fixtures under
+  `tap-mcp-bridge/examples/merchants/` must continue to pass unchanged.
+
+## Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| No algorithm configured | Default to Ed25519 (current behavior, unchanged) |
+| RSA key configured but below minimum strength | Bridge refuses to start / sign, with an explicit error message (mirrors Spec 007's weak-key rejection posture) |
+| RSA key configured but malformed (bad PEM/DER) | Fail fast at load time with a clear parse error, not a silent fallback to Ed25519 |
+| Merchant rejects the chosen algorithm | Out of scope for this spec — algorithm negotiation/fallback (trying both algorithms against a merchant) is a design question for `/sdd plan`, not assumed here |
+| Both an Ed25519 and RSA key configured simultaneously | `[NEEDS CLARIFICATION: is dual-key configuration in scope, or is algorithm selection strictly one-key-one-algorithm per deployment?]` |
+
+## Design Choices (Open Questions for `/sdd plan`)
+
+This research finding intentionally stops short of prescribing HOW.
+Key questions for the planning phase:
+
+1. **Algorithm selection mechanism** — new env var
+   (`TAP_SIGNING_ALGORITHM`), key-format sniffing (detect RSA vs
+   Ed25519 from the key material itself), or explicit
+   `SigningAlgorithm` enum on the library's public API?
+2. **RSA crate choice** — pure-Rust `rsa` crate vs. `ring` vs. an
+   OpenSSL binding; must satisfy `cargo make deny` (license/advisory
+   bans) and the workspace's `unsafe`-avoidance posture.
+3. **Signer abstraction** — does `tap-mcp-bridge/src/tap/signer.rs`
+   need a `Signer` trait with `Ed25519Signer` / `RsaPssSigner`
+   implementations, or a simpler enum-dispatch approach appropriate
+   for an MVP (per this project's "no premature abstraction"
+   convention)?
+4. **JWK/thumbprint impact** — RFC 7638 thumbprint computation differs
+   between OKP (`crv`, `kty`, `x`) and RSA (`e`, `kty`, `n`) member
+   sets; verify the thumbprint module generalizes correctly for both.
+
+## See Also
+
+- [Visa Trusted Agent Protocol reference implementation](https://github.com/visa/trusted-agent-protocol) — `tap-agent/` README documents both Ed25519 and RSA-PSS-SHA256 as supported signing algorithms
+- [RFC 9421 — HTTP Message Signatures](https://www.rfc-editor.org/rfc/rfc9421.html) — §3.3.6 defines `rsa-pss-sha256`; §3.3.7 defines `ed25519` (this bridge's current sole path)
+- [RFC 7518 — JSON Web Algorithms](https://www.rfc-editor.org/rfc/rfc7518.html) — §6.3.1 defines the RSA JWK member set (`n`, `e`) needed to extend `tap-mcp-bridge/src/tap/jwk.rs`
+- [RFC 7638 — JSON Web Key (JWK) Thumbprint](https://www.rfc-editor.org/rfc/rfc7638.html) — thumbprint canonicalization differs by `kty`
+- Spec 007 (`specs/007-weak-signing-keys-accepted/spec.md`) — precedent for weak-key rejection posture, to be mirrored for RSA key strength validation (FR-6)
+- `tap-mcp-bridge/src/tap/acro.rs`, `apc.rs`, `signer.rs`, `jwk.rs` — current Ed25519-only implementation

--- a/specs/010-ap2-x402-landscape-tracking/spec.md
+++ b/specs/010-ap2-x402-landscape-tracking/spec.md
@@ -1,0 +1,157 @@
+# Spec 010 — Track Google Agent Payments Protocol (AP2) and its x402 crypto-payment extension as an emerging parallel standard to Visa TAP
+
+**Status**: Draft
+**Priority**: P4 (Nice-to-have — awareness/tracking item, no urgency, not an active gap)
+**Type**: Research finding — competitive landscape / ecosystem evolution
+**Owner**: TBD
+**Discovered**: Cycle 26, 2026-08-08
+**Source**: [AP2 protocol site](https://ap2-protocol.org/), [Google Cloud announcement](https://cloud.google.com/blog/products/ai-machine-learning/announcing-agents-to-payments-ap2-protocol), [x402 security analysis (arXiv)](https://arxiv.org/pdf/2605.30998)
+
+## Problem Statement
+
+`tap-mcp-bridge` bridges Visa's Trusted Agent Protocol (TAP) with MCP,
+and its entire signing/verification stack (RFC 9421 HTTP message
+signatures, ACRO/APC payloads, JWK thumbprints) is built exclusively
+around TAP's agent-identity/bot-detection model.
+
+As of 2026, a second major agent-payments standard has emerged with
+significant multi-vendor backing: Google's **Agent Payments Protocol
+(AP2)**, currently at v0.2 (April 2026). AP2 differs from TAP in scope
+and mechanism:
+
+- **Payment-rail-agnostic**: AP2 covers cards, bank transfers, and
+  stablecoins, whereas TAP is scoped to agent-identity assertions at
+  the HTTP transaction layer for existing card-network checkout flows.
+- **Mandate-based authorization**: AP2 uses cryptographically signed
+  "mandates" (intent/cart/payment mandate objects) as its core
+  authorization primitive, rather than TAP's RFC 9421 HTTP message
+  signatures over individual requests.
+- **x402 extension**: built with Coinbase, the Ethereum Foundation, and
+  MetaMask, targeting crypto-native/stablecoin agent payments. x402 has
+  already been natively integrated by Google AP2, Cloudflare Agents,
+  Stripe, and AWS Bedrock — indicating broader ecosystem pull than a
+  single-vendor experiment.
+
+TAP and AP2 are not inherently incompatible — TAP answers "is this
+request really coming from a trusted, verifiable agent?" at the HTTP
+layer, while AP2 answers "is this payment authorized, and by whom?" at
+the transaction-mandate layer. In principle a merchant could require
+both for the same checkout flow. However, `tap-mcp-bridge` today has
+**no protocol abstraction boundary** between "TAP-the-transport-and-
+identity-layer" and "TAP-the-only-supported-payment-authorization-
+model" — the bridge's `MerchantApi` trait, tool surface, and signing
+stack all assume TAP end-to-end.
+
+If AP2/x402 adoption continues to grow among merchants and MCP-based
+commerce tooling — particularly given the multi-vendor backing (Google,
+Coinbase, Ethereum Foundation, MetaMask, Cloudflare, Stripe, AWS) — this
+project's exclusive TAP focus becomes a merchant-coverage limitation:
+agents built on `tap-mcp-bridge` cannot reach merchants that require or
+prefer AP2 mandates or x402 stablecoin settlement, regardless of
+whether those merchants also support TAP.
+
+This spec captures the landscape signal and the shape of a possible
+future gap. It is explicitly **not** a commitment to implement AP2/x402
+support, and does not prescribe a design — that decision belongs to a
+later `/sdd plan` cycle, contingent on continued adoption evidence.
+
+## User Stories
+
+### US-1: Agent operator wanting to reach AP2/x402-only merchants
+
+AS A TAP agent operator deploying `tap-mcp-server`
+I WANT to know whether the bridge can (now or via a future extension)
+transact with merchants that only accept AP2 mandates or x402
+stablecoin payments
+SO THAT I can decide whether `tap-mcp-bridge` alone covers my target
+merchant set, or whether I need a separate integration path for
+AP2/x402-only storefronts
+
+**Acceptance criteria:**
+```
+GIVEN an agent operator evaluating tap-mcp-bridge against a merchant
+      that advertises AP2 mandate support (with or without x402)
+      but does not implement TAP
+WHEN the operator checks this project's documented protocol coverage
+THEN the operator finds an explicit statement that AP2/x402 is not
+     currently supported, tracked as a known landscape gap, distinct
+     from a silent capability hole
+```
+
+### US-2: Maintainer deciding whether to prioritize AP2/x402 work
+
+AS A maintainer planning future `tap-mcp-bridge` work
+I WANT a standing, low-noise record of AP2/x402 adoption signals
+SO THAT a future decision to add parallel protocol support is made
+from accumulated evidence (merchant demand, ecosystem integrations)
+rather than from a cold start
+
+**Acceptance criteria:**
+```
+GIVEN this spec exists as a tracking record
+WHEN a future research cycle re-evaluates AP2/x402 adoption
+THEN the cycle can update this spec (or supersede it with a new one)
+     with fresh evidence instead of re-deriving the landscape from
+     scratch
+```
+
+## Functional Requirements
+
+These are intentionally high-level and conditional — they describe
+what a *future* integration would need to consider IF the project ever
+takes on AP2/x402 support. None of them are committed scope for this
+spec.
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | IF AP2/x402 support is ever undertaken, THE SYSTEM MAY expose a pluggable payment-protocol abstraction (distinct from the current TAP-specific `MerchantApi`/signing stack) so that TAP and AP2 code paths do not entangle | could |
+| FR-2 | IF AP2/x402 support is ever undertaken, THE SYSTEM SHALL treat AP2 mandate signing/verification as an additive capability that does not alter existing TAP request/response formats or the default TAP-only code path | must (conditional) |
+| FR-3 | THE SYSTEM SHALL NOT require any AP2/x402-related change as part of this spec; this spec's only mandatory deliverable is the tracking record itself | must |
+| FR-4 | WHEN a future research cycle finds material new AP2/x402 adoption evidence (e.g. named merchant integrations, MCP-ecosystem tooling adopting AP2/x402, TAP-AP2 interop guidance from Visa or Google), THE SYSTEM's spec set SHOULD be updated (this spec revised, or a new spec filed referencing it) rather than the signal being dropped | should |
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Security | IF AP2/x402 support is ever undertaken, it MUST NOT compromise the existing TAP security posture (RFC 9421 signature integrity, replay-protection nonce cache per Spec 008, HTTPS enforcement, loopback/path-traversal/CRLF blocking). Any shared transport code between TAP and AP2 paths must preserve today's security invariants for TAP traffic unchanged. |
+| NFR-2 | Security | The x402 extension has a documented security analysis — ["Free-Riding the Agentic Web: A Systematic Security Analysis of x402 Payments"](https://arxiv.org/pdf/2605.30998) — that catalogs known pitfalls in x402-style payment flows. This MUST be reviewed before any x402 implementation work begins, not treated as optional background reading. |
+| NFR-3 | Compatibility | Any future AP2/x402 work MUST be additive: existing TAP-only deployments, merchant TOML configs, and the current MCP tool surface (`checkout_with_tap`, `browse_merchant`, `get_products`, etc.) must continue to function unchanged. |
+| NFR-4 | Maintainability | This tracking spec SHOULD be revisited on a defined cadence (e.g. each landscape-scanning research cycle, per `.claude/rules/continuous-improvement.md`) rather than left stale indefinitely, given standards in this space are evolving quickly (AP2 was at v0.2 as of April 2026). |
+
+## Edge Cases and Error Handling
+
+Not applicable in the traditional sense — this is a landscape-tracking
+spec with no implementation. The table below instead captures decision
+triggers for escalating this from "tracked" to "actionable":
+
+| Scenario | Expected Handling |
+|----------|--------------------|
+| A specific merchant integration `tap-mcp-bridge` is targeting requires AP2/x402 and has no TAP fallback | Escalate this spec's priority (P4 → higher) and file a follow-up `/sdd specify` scoped to that concrete merchant requirement, rather than expanding this landscape spec |
+| AP2 or x402 specification changes materially (e.g. AP2 reaches v1.0, or TAP publishes explicit AP2 interop guidance) | Update this spec's Problem Statement and re-check the "not an active incompatibility" framing |
+| No further adoption signal appears over multiple research cycles | Leave as-is; do not escalate priority without new evidence |
+
+## Agent Boundaries
+
+### Always (without asking)
+- Treat this spec as informational/tracking only — no code changes are implied or required by its existence
+
+### Ask First
+- Starting any implementation work toward AP2/x402 support (this would require a dedicated `/sdd specify` + `/sdd plan` cycle with explicit scope, not an extension of this tracking spec)
+
+### Never
+- Infer authorization to add AP2/x402 dependencies, new signing algorithms, or protocol abstractions from this spec alone
+- Treat FR-1/FR-2 (MAY/conditional requirements) as committed deliverables
+
+## Open Questions
+
+- `[NEEDS CLARIFICATION: does the project want a recurring "protocol landscape watch" item in the continuous-improvement cycle (per .claude/rules/continuous-improvement.md's "Reference Projects" section), or is a one-off spec update sufficient when new evidence appears?]`
+- `[NEEDS CLARIFICATION: is there a specific merchant or MCP-ecosystem partner currently requesting AP2/x402 support, or is this purely proactive landscape awareness?]`
+- `[NEEDS CLARIFICATION: should Visa's TAP roadmap (if any public signal exists) addressing AP2 interoperability be tracked separately, since that would reduce the urgency of a bridge-side dual-protocol implementation?]`
+
+## See Also
+
+- [AP2 protocol documentation](https://ap2-protocol.org/) — protocol overview, mandate model, v0.2 spec
+- [Google Cloud: Announcing Agents to Payments (AP2) Protocol](https://cloud.google.com/blog/products/ai-machine-learning/announcing-agents-to-payments-ap2-protocol) — vendor announcement and ecosystem backing
+- [Free-Riding the Agentic Web: A Systematic Security Analysis of x402 Payments (arXiv)](https://arxiv.org/pdf/2605.30998) — required reading before any x402 implementation work (NFR-2)
+- Spec 009 (`specs/009-rsa-pss-signing-support/spec.md`) — prior algorithm-parity research finding against the TAP reference implementation; same "capture what/why, defer how to `/sdd plan`" pattern
+- `tap-mcp-bridge/src/lib.rs` — current TAP-only architecture entry point; would be the anchor point for any future protocol abstraction (FR-1)

--- a/specs/011-process-payment-acro-wire-contract/spec.md
+++ b/specs/011-process-payment-acro-wire-contract/spec.md
@@ -1,0 +1,255 @@
+# Spec 011 — `process_payment` discards ACRO/ID-token signature; ACRO has no wire slot for any body-bearing TAP request
+
+**Status**: Draft
+**Priority**: P1 (High — matches issue #239 severity; scope is broader than originally filed)
+**Type**: Bug fix / design decision (resolves the "NEEDS SPEC" flag on #239)
+**Owner**: TBD
+**Discovered**: Cycle 27, 2026-08-08 (CI-027 architecture audit, filed as #239; this spec broadens the finding after reading the sibling function)
+**Source**: [Issue #239](https://github.com/bug-ops/tap-mcp-bridge/issues/239), [Issue #240](https://github.com/bug-ops/tap-mcp-bridge/issues/240) (shared-executor duplication), `tap-mcp-bridge/src/mcp/http.rs`, `tap-mcp-bridge/src/mcp/cart.rs`, `tap-mcp-bridge/src/mcp/tools.rs`, `tap-mcp-bridge/src/mcp/subscriptions/tools.rs`, `tap-mcp-bridge/src/tap/acro.rs`
+
+## Problem Statement
+
+Issue #239 reports that `execute_tap_request_with_custom_nonce`
+(`tap-mcp-bridge/src/mcp/http.rs:249-312`), the sole request path used
+by `process_payment`, generates a full ID token and ACRO (two Ed25519
+signing operations) from caller-supplied `country_code`/`zip`/
+`ip_address`/`user_agent`/`platform` fields, then discards the ACRO
+with `let _ = acro;` and sends only `ProcessPaymentRequest { order_id,
+apc }` — no ACRO, no fraud-context data reaches the merchant. The
+issue frames this as a divergence from the "sibling" function
+`execute_tap_request_with_acro`, which supposedly *does* transmit
+ACRO, and asks this spec to determine whether `process_payment` should
+adopt that sibling's behavior or drop the dead ACRO generation
+entirely.
+
+**Reading `execute_tap_request_with_acro` closely changes the answer.**
+It does not always transmit ACRO either:
+
+```rust
+// tap-mcp-bridge/src/mcp/http.rs:189-196
+let body = if let Some(req_body) = request_body {
+    serde_json::to_vec(req_body)?     // ACRO computed above, never touched again
+} else {
+    serde_json::to_vec(&acro)?        // ACRO becomes the ENTIRE body
+};
+```
+
+ACRO is only ever placed on the wire when `request_body` is `None` —
+i.e. when the endpoint has no JSON payload of its own and ACRO
+substitutes for it wholesale. Cross-referencing every call site:
+
+| Caller | Method | `request_body` | ACRO transmitted? |
+|---|---|---|---|
+| `cart::get_cart` (`cart.rs:215`) | GET | `None::<&()>` | Yes — ACRO *is* the body |
+| `subscriptions::tools` (5 GET calls, e.g. `:454`, `:504`, `:1005`) | GET | `None` | Yes — ACRO *is* the body |
+| `tools::checkout_with_tap` (private variant, `tools.rs:185`) | POST | n/a — always ACRO body | Yes — no other payload exists |
+| `tools::browse_merchant` (private variant, `tools.rs:255`) | GET | n/a — always ACRO body | Yes — no other payload exists |
+| `cart::add_to_cart` (`cart.rs:170`) | POST | `Some(&request_body)` | **No** — ACRO generated, discarded |
+| `cart::update_cart_item` (`cart.rs:267`) | PUT | `Some(&request_body)` | **No** |
+| `cart::remove_from_cart` (`cart.rs:317`) | DELETE | `Some(&request_body)` | **No** |
+| `subscriptions::tools` (6 POST/PUT calls, e.g. `:589`, `:639`, `:711`, `:773`, `:840`, `:899`, `:963`, `:1077`, `:1141`) | POST/PUT | `Some(&request_body)` | **No** |
+| `payment::process_payment` (`http.rs:249-312`, custom-nonce variant) | POST | always `Some` (no `Option` at all) | **No** (issue #239) |
+
+So `execute_tap_request_with_custom_nonce`'s `let _ = acro;` is not an
+isolated regression from a working pattern — it is **the same code
+shape and the same defect** as every `Some(request_body)` call through
+`execute_tap_request_with_acro`. The only functions that actually put
+ACRO on the wire are the four GET-style / no-payload calls, where ACRO
+happens to be the only content available to serialize. There is no
+implemented mechanism anywhere in this codebase — no header, no
+wrapper body field, no `Signature-Input` component — for ACRO to
+accompany a request that already carries its own JSON payload:
+
+- `tap-mcp-bridge/src/tap/mod.rs` documents the RFC 9421 signature
+  base as covering exactly `@method`, `@authority`, `@path`, and
+  `content-digest` — no ACRO-related signed component exists.
+- No header named `Acro`, `X-Tap-Acro`, or similar appears anywhere
+  under `tap-mcp-bridge/src/` (verified by grep).
+- No test in `acro.rs`, `http.rs`, `cart.rs`, or the
+  `subscriptions` module exercises "ACRO alongside a body" — every
+  ACRO test constructs and signs the object in isolation, never
+  checks it against a transmitted request.
+- No merchant TOML fixture, doc comment, or module doc in this
+  project describes a wire slot for "ACRO + JSON payload" together.
+
+This reframes the design question #239 asked. It is not "should
+`process_payment` copy what its sibling does" — the sibling doesn't do
+it either for any body-bearing call. The real question is: **does the
+TAP wire protocol require consumer-recognition context (ACRO) to
+accompany body-bearing requests at all, and if so, where does it go?**
+This bridge's own implementation has never answered that question for
+*any* endpoint; `process_payment` merely makes the gap most visible
+because payment is the highest-stakes, most fraud-sensitive path and
+its doc comment (`payment.rs:148`, "Generates TAP signature with
+ACRO") explicitly promises behavior the code does not deliver.
+
+## User Stories
+
+### US-1: Merchant fraud/risk system relying on consumer context
+
+AS A merchant operator running fraud/risk scoring on incoming TAP
+checkout and cart-mutation requests
+I WANT the consumer's declared location, IP, and device context (ACRO)
+to actually reach my server on every request that carries it
+SO THAT my risk engine can evaluate agent-initiated purchases with the
+same contextual signal a human checkout flow would provide
+
+**Acceptance criteria:**
+```
+GIVEN a caller supplies country_code/zip/ip_address/user_agent/platform
+      to process_payment (or add_to_cart, update_cart_item, any other
+      body-bearing TAP call)
+WHEN the bridge sends the request to the merchant
+THEN the merchant either receives the ACRO object on the wire (if
+     Position A is adopted) or the caller is not asked to supply
+     contextual data that is silently thrown away (if Position B is
+     adopted) — never the current state where the data is requested,
+     signed, and discarded without any signal to the caller
+```
+
+### US-2: Maintainer implementing the fix
+
+AS A developer implementing the resolution to #239
+I WANT a single, explicit wire-contract decision that covers
+`process_payment` AND the systemic gap in `execute_tap_request_with_acro`
+SO THAT I don't ship a `process_payment`-only patch that leaves the
+identical defect live in `add_to_cart`, `update_cart_item`,
+`remove_from_cart`, and every subscription mutation call
+
+**Acceptance criteria:**
+```
+GIVEN this spec's recommended position (see Recommendation)
+WHEN the fix lands
+THEN process_payment's doc comment accurately describes what is sent,
+     no Ed25519 signing operation's output is silently discarded on
+     that path, and a new issue exists tracking the identical pattern
+     in the other Some(request_body) call sites so the fix is not
+     re-litigated per-endpoint
+```
+
+## Recommendation
+
+**Position B — remove the dead ACRO/ID-token generation from
+`process_payment`'s request path; do not attempt to invent a wire slot
+for ACRO-alongside-body as part of resolving #239.**
+
+Justification:
+
+1. **No wire contract exists to extend.** Position A ("make
+   `process_payment` transmit ACRO like its sibling does") is not
+   actually available — the sibling doesn't transmit ACRO for any
+   body-bearing call either. Adopting Position A for `process_payment`
+   alone would require inventing a new wire mechanism (header or body
+   envelope) from scratch, unvalidated against any TAP reference
+   material available to this project, and would leave `add_to_cart`,
+   `update_cart_item`, `remove_from_cart`, and every subscription
+   mutation with the identical unaddressed gap. That is a materially
+   larger design effort than #239's stated scope ("resolve the ACRO
+   wire contract for `process_payment`") and belongs in its own
+   `/sdd plan` cycle once a concrete TAP wire format is confirmed
+   — see Open Questions.
+2. **Same defect class as Spec 001.** Spec 001
+   (`specs/001-cart-id-silently-dropped/spec.md`) resolved an
+   analogous "field accepted, signed/validated, never reaches the
+   wire" defect for `cart_id` by choosing, per-case, either to route
+   the field onto the wire or to remove it and document the breaking
+   change (FR-5 in that spec). The same two-option structure applies
+   here, and for the reasons in point 1, the "remove it" branch is the
+   correct choice for `process_payment` specifically: nothing in this
+   codebase currently defines where ACRO would go on a body-bearing
+   request, so there is nothing concrete to route it onto.
+3. **Wasted cryptographic work compounds the case for removal, not
+   extension.** Every `process_payment` call currently performs two
+   Ed25519 signing operations (`generate_id_token`, `generate_acro`)
+   whose output is discarded. Removing them is a pure win with zero
+   behavior change to what the merchant already receives (nothing).
+   Extending the wire format instead would add complexity and CPU
+   cost on the payment critical path for a benefit (fraud-context
+   delivery) that cannot yet be verified against merchant expectations.
+4. **`ProcessPaymentParams` currently over-collects.** Requiring every
+   caller to supply `country_code`, `zip`, `ip_address`, `user_agent`,
+   `platform` — and signing them into an ACRO that is then thrown away
+   — is worse than not collecting them: it creates a false impression
+   (reinforced by the doc comment) that this data reaches the
+   merchant and influences fraud scoring, when it does not. Removing
+   the dead generation should also remove or clearly re-scope these
+   fields (see FR-3) so the API contract matches actual behavior.
+5. **This is reversible and additive-safe.** Per this project's
+   pre-1.0 conventions, removing unused fields now is a documented
+   breaking change (`CHANGELOG.md`), not a permanent foreclosure. If a
+   future spec establishes a concrete TAP wire slot for
+   ACRO-alongside-body (Position A, properly scoped across *all*
+   affected call sites), `ProcessPaymentParams` can re-add the fields
+   at that point with full test coverage, rather than carrying
+   dead-but-signed fields indefinitely in the meantime.
+
+This is **not** a claim that ACRO/consumer-context delivery on
+body-bearing requests is unimportant — it is a claim that this
+specific issue (#239) cannot responsibly resolve that question by
+patching one endpoint, because the answer doesn't exist anywhere in
+this codebase yet for any endpoint. See FR-5 and Open Questions for
+the follow-up this spec requires.
+
+## Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | `execute_tap_request_with_custom_nonce` (`http.rs:249-312`) SHALL NOT call `signer.generate_id_token` or `signer.generate_acro` when their output is not placed on the wire. The function SHALL either transmit what it signs or not sign it. | must |
+| FR-2 | `process_payment` (`payment.rs:218-274`) SHALL stop passing `contextual_data` through to the (now-corrected) executor for a purpose that discards it. If FR-5's shared executor still accepts a `contextual_data` parameter for API consistency with the ACRO-transmitting call sites, `process_payment`'s call SHALL NOT trigger ACRO generation. | must |
+| FR-3 | `ProcessPaymentParams`'s `country_code`, `zip`, `ip_address`, `user_agent`, `platform` fields SHALL be removed, since nothing in the corrected code path consumes them. This is a breaking change; document it in `CHANGELOG.md` `[Unreleased]` per project convention. | must |
+| FR-4 | The doc comment on `process_payment` (currently: "2. Generates TAP signature with ACRO") SHALL be corrected to describe actual behavior: TAP signature generation without ACRO for this endpoint. | must |
+| FR-5 | A new issue SHALL be filed (referencing this spec, #239, and #240) covering the identical `let _ = acro`-equivalent pattern present in every `Some(request_body)` call to `execute_tap_request_with_acro` (`add_to_cart`, `update_cart_item`, `remove_from_cart`, and the 8+ subscription mutation calls enumerated in the Problem Statement table). That issue SHOULD propose either (a) stop generating ACRO for those calls too (mirroring this spec's Position B), or (b) a proper `/sdd specify` + `/sdd plan` cycle to design a real ACRO-alongside-body wire mechanism, validated against TAP reference material, applied uniformly across all affected endpoints — not decided ad hoc per call site. | must |
+| FR-6 | Existing regression test coverage for `process_payment` (`payment.rs` `#[cfg(test)]` module) MUST be extended to assert that no ACRO-shaped signing side effect occurs (e.g. via a spy/mock signer or an integration test asserting the transmitted body is exactly `ProcessPaymentRequest`, no more) — mirroring how Spec 001 required a wire-level regression test for its equivalent fix. | must |
+| FR-7 | The shared-executor refactor tracked by issue #240 SHOULD incorporate this spec's fix directly (i.e. do not implement FR-1/FR-2 in the current duplicated `execute_tap_request_with_custom_nonce`, then redo the same edit when #240's deduplication lands) if #240 is scheduled for the same development cycle. If #240 is not imminent, implement FR-1/FR-2 in the existing function as-is; #240 remains a separate, independently valuable cleanup. | should |
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Performance | Removing the two discarded Ed25519 signing operations per `process_payment` call reduces CPU cost on the payment critical path. No new NFR beyond "do not regress this" — the fix is a straightforward removal. |
+| NFR-2 | Compatibility | Pre-1.0 breaking change (FR-3's field removal) — no deprecation shim; record in `CHANGELOG.md` `[Unreleased]` per project convention (`CLAUDE.md`, `.claude/rules/branching.md`). |
+| NFR-3 | Documentation | If `tap-mcp-server`'s MCP tool schema for `checkout_with_tap`/payment tooling documents these fields externally (README, tool `inputSchema`), it MUST be updated to match `ProcessPaymentParams`'s corrected shape (`.claude/rules/branching.md`: "If touching MCP tool surface, update `tap-mcp-server` README/docs"). |
+| NFR-4 | Cross-interface consistency | Per `.claude/rules/continuous-improvement.md`, any change to ACRO/APC/ID-token generation logic must be exercised through both a library example and the `tap-mcp-server` MCP tool path — verify `process_payment`'s example (`payment.rs` doc-test, `basic_checkout`/`full_checkout_flow` examples if they exercise payment) still compiles and runs after FR-3's field removal. |
+| NFR-5 | Security | This fix has no negative security impact: it removes signing operations whose output was never transmitted, so no signature or replay-protection guarantee weakens. It does, however, mean `process_payment` sends strictly less consumer-context data to the merchant than the (never-functional) doc comment implied — flag this in the CHANGELOG as a behavioral clarification, not a regression, since the data never reached the merchant either way. |
+
+## Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Existing caller code still populates the now-removed `country_code`/`zip`/`ip_address`/`user_agent`/`platform` fields on `ProcessPaymentParams` | Compile error (struct field removed) — correct pre-1.0 behavior per project convention; document migration in `CHANGELOG.md` |
+| `execute_tap_request_with_custom_nonce` is reused by a future caller that *does* want ACRO transmitted | Not supported by this spec's fix (FR-1 removes ACRO generation unconditionally from this function). If a future endpoint needs ACRO-alongside-body, it must go through the FR-5 follow-up issue's proper design, not silently reintroduce the discard-prone pattern here |
+| `execute_tap_request_with_acro`'s existing `Some(request_body)` call sites (`add_to_cart`, etc.) | Explicitly out of scope for this spec's implementation (tracked separately per FR-5); do not touch as part of resolving #239 to keep the PR reviewable and scoped |
+| A future TAP spec revision defines exactly where ACRO belongs on a body-bearing request | Re-open via the FR-5 follow-up issue; this spec's Position B is not permanent, it is the correct choice given the *current* absence of any implemented or documented wire slot |
+
+## Agent Boundaries
+
+### Always (without asking)
+- Read `tap-mcp-bridge/src/mcp/http.rs`, `payment.rs` fully before editing, to avoid re-breaking the `Some`/`None` branch structure shared with `execute_tap_request_with_acro`
+- Update `CHANGELOG.md` `[Unreleased]` for the `ProcessPaymentParams` breaking change (FR-3)
+- Run the full local check suite (`cargo make pre-commit` or the direct cargo equivalents) before considering the fix complete
+
+### Ask First
+- Extending this fix to also remove ACRO generation from `execute_tap_request_with_acro`'s `Some(request_body)` call sites — that is FR-5's separate issue, not this spec's implementation scope, even though the code shape is identical
+- Any decision to instead pursue Position A (invent an ACRO-alongside-body wire mechanism) — that requires new TAP reference material this spec did not have access to, and a dedicated `/sdd specify` cycle
+
+### Never
+- Ship a `process_payment`-only fix while leaving its doc comment inaccurate, or vice versa (doc comment and code must be corrected together, per FR-4)
+- Silently drop the `ProcessPaymentParams` fields without a `CHANGELOG.md` entry — this is a breaking API change
+
+## Open Questions
+
+- `[NEEDS CLARIFICATION: is there authoritative TAP specification text (beyond what's referenced in this codebase's module docs) that defines a header or body-envelope mechanism for ACRO to accompany a request that already carries its own JSON payload? This spec's recommendation (Position B) is contingent on no such mechanism being currently implementable in this codebase; if TAP reference material surfaces one, Position A should be revisited via a new spec scoped across all affected endpoints, not just process_payment.]`
+- `[NEEDS CLARIFICATION: does removing consumer-context collection from process_payment reduce this bridge's fraud-prevention posture in a way that matters to a specific merchant integration, or is APC (Agentic Payment Container) alone considered sufficient for payment-stage authentication, with ACRO reserved for browse/cart-context establishment only? If the latter, this strengthens Position B further — ACRO may be architecturally scoped to browse/read interactions by design, not merely by implementation gap.]`
+- `[NEEDS CLARIFICATION: should the FR-5 follow-up issue be filed as part of this spec's closure, or deferred until #240's shared-executor refactor is scheduled, since fixing the Some(request_body) call sites likely touches the same executor code #240 targets?]`
+
+## See Also
+
+- [Issue #239](https://github.com/bug-ops/tap-mcp-bridge/issues/239) — original finding this spec resolves
+- [Issue #240](https://github.com/bug-ops/tap-mcp-bridge/issues/240) — near-duplicate executor logic; FR-7 recommends coordinating implementation order
+- Spec 001 (`specs/001-cart-id-silently-dropped/spec.md`) — precedent for the "route it onto the wire, or remove it and document the breaking change" decision structure applied here
+- `tap-mcp-bridge/src/mcp/http.rs:150-312` — `execute_tap_request_with_acro` and `execute_tap_request_with_custom_nonce`, both examined for this spec
+- `tap-mcp-bridge/src/mcp/payment.rs:218-274` — `process_payment`, the fix target
+- `tap-mcp-bridge/src/mcp/cart.rs:150-330` — `add_to_cart`/`update_cart_item`/`remove_from_cart`, cited as evidence of the systemic `Some(request_body)` discard pattern (FR-5 scope, not this spec's implementation scope)
+- `tap-mcp-bridge/src/mcp/subscriptions/tools.rs` — additional `Some(request_body)` call sites with the same pattern (FR-5 scope)
+- `tap-mcp-bridge/src/tap/acro.rs` — `Acro`/`ContextualData`/`DeviceData` definitions and module docs (no header/body-envelope mechanism documented)
+- `.claude/rules/continuous-improvement.md` — cross-interface consistency requirement (NFR-4)

--- a/specs/012-tap-protocol-implementation/spec.md
+++ b/specs/012-tap-protocol-implementation/spec.md
@@ -1,0 +1,122 @@
+# Spec 012 — `tap` Subsystem: RFC 9421 Signatures, JWK/JWT, ACRO/APC
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, to close the
+subsystem-coverage gap identified against `.claude/rules/continuous-improvement.md`
+§ Project Subsystems (the 11 pre-existing specs are individual bug-fix/finding
+specs, not subsystem-level documentation)
+**Source**: `tap-mcp-bridge/src/tap/{mod,signer,verifier,jwk,jwt,acro,apc}.rs`
+
+> [!note]
+> This spec describes the `tap` module **as currently implemented**. It is not a
+> proposal for new functionality — every requirement below is a description of
+> code that already exists and is tested. Its purpose is to give a coding agent
+> (or reviewer) a single reference for this subsystem's contract without reading
+> every source file, and to serve as the baseline against which future changes
+> (e.g. spec [[009-rsa-pss-signing-support]], spec [[008-replay-cache-lru-eviction]])
+> are diffed.
+
+## 1. Overview
+
+### Problem Statement
+
+The bridge must let an AI agent prove its identity to a merchant on every HTTP
+request, per Visa's Trusted Agent Protocol (TAP). TAP defines this proof as an
+RFC 9421 HTTP Message Signature over Ed25519, plus a set of TAP-specific
+payloads (JWKS for public key distribution, JWT ID tokens, ACRO for consumer
+context, APC for encrypted payment data). The `tap` module is the sole place in
+the codebase where these cryptographic primitives are constructed; every other
+module (`mcp`, `merchant`) calls into it rather than re-implementing signing.
+
+### Goal
+
+A single `TapSigner` instance, constructed once from an `Ed25519` signing key
+and an agent identity, can produce every TAP-required artifact (request
+signature, JWKS, ID token, ACRO, APC) needed for a full checkout/browse
+interaction, and a paired `TapVerifier` can validate an inbound signed request
+including replay protection.
+
+### Out of Scope
+
+- Transport/HTTP client concerns (see [[016-transport-layer]] and `mcp/http.rs`,
+  covered in [[014-mcp-tool-surface]])
+- JWE compact serialization internals (see [[013-jwe-encryption]] — `tap`
+  depends on it for `Apc::create` but does not implement it)
+- RSA-PSS-SHA256 as an alternative signing algorithm — not yet implemented;
+  tracked separately in [[009-rsa-pss-signing-support]]
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `TapSigner` | Holds the agent's Ed25519 signing key and identity; the sole signing entry point | `signing_key: SigningKey`, `agent_id: String`, `agent_directory: Arc<str>` |
+| `TapSignature` | Output of `sign_request` — the four TAP HTTP headers | `signature`, `signature_input`, `agent_directory`, `nonce` |
+| `InteractionType` | Distinguishes browse vs. checkout interactions for the `tag` signature parameter | `Browse` → `"agent-browser-auth"`, `Checkout` → `"agent-payer-auth"` |
+| `TapVerifier` | Validates inbound signed requests and tracks replay state | `nonce_cache: Arc<Mutex<NonceCache>>` |
+| `Jwk` / `Jwks` | Public key material for the agent directory endpoint | `kty, crv, x, kid, alg, key_use`; `Jwks.keys: Vec<Jwk>` |
+| `IdTokenClaims` / `IdToken` | JWT proving consumer identity to the merchant | `sub, iss, aud, exp, iat, nonce, agent_directory` |
+| `Acro` | Agentic Consumer Recognition Object — consumer/device context, signed | `nonce, id_token, contextual_data, kid, alg, signature` |
+| `ContextualData` / `DeviceData` | Fields carried inside ACRO | `country_code, zip, ip_address` / `user_agent, platform` |
+| `Apc` | Agentic Payment Container — encrypted payment method, signed | `nonce, encrypted_payment_data, kid, alg, signature` |
+| `PaymentMethod` | Card / BankAccount / DigitalWallet payload encrypted into APC | `Card(CardData) \| BankAccount(BankAccountData) \| DigitalWallet(DigitalWalletData)` |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN `TapSigner::sign_request` is called with method, authority, path, body, and an `InteractionType` THE SYSTEM SHALL produce a `TapSignature` whose `signature_input` covers `@method`, `@authority`, `@path`, `content-digest`, `created`, `expires`, `nonce`, `keyid`, `alg`, and `tag`, per RFC 9421 | must |
+| FR-2 | WHEN a signature is generated THE SYSTEM SHALL set `expires - created` to at most `TAP_MAX_VALIDITY_WINDOW_SECS` (480s / 8 minutes), per TAP's maximum validity window requirement | must |
+| FR-3 | WHEN `TapSigner::generate_jwks` is called THE SYSTEM SHALL derive `kid` as the RFC 7638 JWK thumbprint of the agent's Ed25519 public key | must |
+| FR-4 | WHEN `TapVerifier::verify_request` is called with a signature that reuses a nonce already present and unexpired in the nonce cache THE SYSTEM SHALL reject the request with `BridgeError::ReplayAttack` | must |
+| FR-5 | WHEN the nonce cache is at capacity and a new nonce must be recorded THE SYSTEM SHALL reject the request with `BridgeError::ReplayCacheSaturated` rather than evict an unexpired entry to make room (fail-closed; see [[008-replay-cache-lru-eviction]] for the incident this behavior resolves) | must |
+| FR-6 | WHEN `TapSigner::generate_acro` or `generate_apc` is called THE SYSTEM SHALL compute the signature over the canonical JSON of all fields except `signature` itself, and set `kid` to the same RFC 7638 thumbprint used in FR-3 | must |
+| FR-7 | WHEN a `CardData`/`BankAccountData` value is formatted via `{:?}` (`Debug`) THE SYSTEM SHALL redact the PAN/CVV/account/routing numbers, showing at most the last 4 digits | must |
+| FR-8 | WHEN a `CardData`/`BankAccountData`/`DigitalWalletData` value is dropped THE SYSTEM SHALL zero its memory (`zeroize()`) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Security | Clock skew tolerance is fixed at 60 seconds (`CLOCK_SKEW_TOLERANCE_SECS`); a `RequestTooOld` error is returned outside the combined validity + skew window |
+| NFR-2 | Security | The only supported signing algorithm today is Ed25519. No algorithm negotiation or downgrade path exists in `sign_request` (relevant to spec [[009-rsa-pss-signing-support]]) |
+| NFR-3 | Testability | Every file in the module has an inline `#[cfg(test)]` module; `tap/tests/proptest_signatures.rs` adds property-based round-trip coverage for signature generation/verification |
+| NFR-4 | Performance | No `criterion` benchmark currently exists for RFC 9421 signing, ACRO/APC serialization, or JWT issuance — this is a known coverage gap per `.claude/rules/continuous-improvement.md` § Performance & Benchmark Coverage, not something this spec resolves |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| Nonce cache constructed with `capacity = 0` | Falls back to a default capacity of 1000 (`TapVerifier::new(0)`) |
+| Signature `created`/`expires` outside the 480s window | `verify_request` returns `RequestTooOld` |
+| `kid` in an ACRO/APC does not match the signer's own JWK thumbprint | Verification fails with `CryptoError` (mismatched key identification) |
+| Nonce cache full of entries that have not yet expired | New signatures are rejected (`ReplayCacheSaturated`), never silently evicted (FR-5) |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Route all new signing/verification logic through `TapSigner`/`TapVerifier` — never construct a raw RFC 9421 signature base outside this module
+- Keep the 480-second validity cap and 60-second skew tolerance unless a spec explicitly changes them
+
+### Ask First
+- Adding a second signing algorithm (RSA-PSS) — see [[009-rsa-pss-signing-support]] for the open research spec that must resolve first
+- Changing the nonce-cache fail-closed policy (FR-5) — this is a deliberate security posture, not an oversight
+
+### Never
+- Log or `Debug`-print raw `CardData`/`BankAccountData`/`DigitalWalletData` contents outside the redacted `Debug` impl
+- Widen the signature validity window beyond what TAP's spec permits without a dedicated spec change
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: is RSA-PSS-SHA256 support (spec 009) still planned, and if so, does it require a breaking change to TapSigner's single-algorithm design, or an additive enum-based signer?]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[008-replay-cache-lru-eviction]] — the incident that produced FR-5's fail-closed policy
+- [[009-rsa-pss-signing-support]] — open research on adding a second signing algorithm
+- [[013-jwe-encryption]] — `Apc::create` depends on this subsystem for compact serialization
+- [[011-process-payment-acro-wire-contract]] — analysis of when ACRO output actually reaches the wire (a `mcp`-layer concern, not a `tap`-layer one)
+- `tap-mcp-bridge/src/tap/mod.rs` — module entry point and signature base documentation

--- a/specs/013-jwe-encryption/spec.md
+++ b/specs/013-jwe-encryption/spec.md
@@ -1,0 +1,107 @@
+# Spec 013 — `jwe` Subsystem: RFC 7516 Compact Serialization for APC Payment Data
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-bridge/src/tap/jwe.rs`
+
+> [!note]
+> Describes existing, tested code. `jwe` lives physically under `tap/` but is
+> tracked as its own logical subsystem in this project's continuous-improvement
+> rules because it has an independent RFC (7516) and its own security
+> properties distinct from the RFC 9421 signing in [[012-tap-protocol-implementation]].
+
+## 1. Overview
+
+### Problem Statement
+
+`Apc::create` (in the `tap` subsystem) needs to encrypt a consumer's payment
+method (card, bank account, digital wallet) so that only the merchant's RSA
+key holder can read it, while everything else in the ACRO/APC envelope stays
+signed but unencrypted. The `jwe` module implements RFC 7516 JWE compact
+serialization for exactly this purpose, built directly on `aws-lc-rs`
+primitives rather than a general-purpose JOSE crate, to avoid pulling in
+OpenSSL.
+
+### Goal
+
+Given an RSA public key (merchant-supplied, SPKI-encoded PEM or DER) and a
+plaintext payload, produce a valid 5-part RFC 7516 compact-serialized JWE
+string using a fixed algorithm pair, with no key or IV reuse across calls.
+
+### Out of Scope
+
+- JWE decryption (this module only encrypts — the bridge is the sender, not
+  the receiver, of APC payloads)
+- Algorithm negotiation — `RSA-OAEP-256` + `A256GCM` are hardcoded, not
+  configurable
+- ACRO/APC signing (see [[012-tap-protocol-implementation]])
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `RsaPublicKey` | Parsed merchant RSA public key | `spki_der: Vec<u8>`, `key_size_bits: usize` |
+| JWE compact string | The output artifact | 5 base64url segments: protected header, encrypted key, IV, ciphertext, auth tag |
+
+Constants: `PROTECTED_HEADER_JSON = {"alg":"RSA-OAEP-256","enc":"A256GCM"}`
+(fixed, also serves as AEAD associated data), `A256GCM_KEY_LEN = 32`,
+`A256GCM_IV_LEN = 12`, `MIN_RSA_KEY_BITS = 2048`.
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN `RsaPublicKey::from_pem` receives a PEM block THE SYSTEM SHALL accept only X.509 SubjectPublicKeyInfo (`-----BEGIN PUBLIC KEY-----`) form and SHALL reject PKCS#1 (`-----BEGIN RSA PUBLIC KEY-----`) form with a distinct error | must |
+| FR-2 | WHEN a parsed RSA key has fewer than `MIN_RSA_KEY_BITS` (2048) bits THE SYSTEM SHALL reject it at parse time | must |
+| FR-3 | WHEN `encrypt_compact` is called THE SYSTEM SHALL generate a fresh Content Encryption Key (CEK) and IV via `aws_lc_rs::rand::SystemRandom` for every call — no key or IV is ever reused across invocations | must |
+| FR-4 | WHEN AES-256-GCM sealing is performed THE SYSTEM SHALL use the base64url-encoded protected header bytes as the AEAD associated data, per RFC 7516 §5.1 step 14 | must |
+| FR-5 | WHEN encryption completes (success or error) THE SYSTEM SHALL zero the CEK in memory (`zeroize::Zeroize`), including on error paths | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Security | Ciphertext tampering (bit-flip in any of the 5 segments) MUST cause AEAD authentication failure — verified by an inline test |
+| NFR-2 | Compatibility | Whitespace variation in input PEM is tolerated (verified by an inline test) |
+| NFR-3 | Portability | `aws-lc-rs`'s FFI is incompatible with Miri; the affected tests are `#[cfg_attr(miri, ignore)]` |
+| NFR-4 | Performance | No `criterion` benchmark exists yet for JWE encryption — known gap, not resolved by this spec |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| PKCS#1 PEM supplied instead of SPKI | Rejected with a distinct, identifiable error message (not silently mis-parsed) |
+| RSA key < 2048 bits | Rejected at parse time, before any encryption is attempted |
+| Empty plaintext payload | Encrypts successfully (covered by an inline round-trip test) |
+| Large plaintext payload | Encrypts successfully (covered by an inline round-trip test) |
+| Ciphertext or auth tag modified after encryption | Decryption (by the merchant, out of scope here) fails; this module's own tests verify the ciphertext is not trivially forgeable |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Generate a fresh CEK/IV per `encrypt_compact` call — never cache or reuse
+- Zeroize CEK material on every code path, including early returns on error
+
+### Ask First
+- Adding a second key-wrap or content-encryption algorithm (currently hardcoded to `RSA-OAEP-256` / `A256GCM`)
+- Adding JWE decryption support (would change this module's role from sender-only to bidirectional)
+
+### Never
+- Accept PKCS#1-format RSA public keys as equivalent to SPKI
+- Reduce `MIN_RSA_KEY_BITS` below 2048 without a dedicated security review
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: does any current or planned merchant integration require JWE decryption (bridge as receiver), or is sender-only always sufficient given TAP's payment-container direction?]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[012-tap-protocol-implementation]] — `Apc::create` is the sole caller of this module's `encrypt_compact`
+- `tap-mcp-bridge/src/tap/jwe.rs` — full implementation and inline tests
+- `tap-mcp-bridge/examples/apc_generation.rs` — example usage

--- a/specs/014-mcp-tool-surface/spec.md
+++ b/specs/014-mcp-tool-surface/spec.md
@@ -1,0 +1,117 @@
+# Spec 014 — `mcp` Subsystem: TAP Operations Exposed as Callable Tools
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-bridge/src/mcp/{mod,tools,models,http,cart,orders,payment,products}.rs`,
+`tap-mcp-bridge/src/mcp/subscriptions/{mod,tools,models,lifecycle,pricing,proration}.rs`
+
+> [!note]
+> Describes existing, tested code. This is the largest subsystem by surface
+> area — it is the library-side implementation consumed by the
+> `tap-mcp-server` binary (see [[020-tap-mcp-server-binary]]) to expose MCP
+> tools over stdio.
+
+## 1. Overview
+
+### Problem Statement
+
+An AI agent needs a catalog of async, strongly-typed operations — browse,
+cart, checkout, orders, payment, subscriptions — that internally handle TAP
+signing, HTTP transport, and merchant-specific request/response shaping. The
+`mcp` module is this catalog: every public `async fn` here takes a `&TapSigner`
+plus a `Params` struct and returns a typed `Result`.
+
+### Goal
+
+Every commerce operation the bridge supports (legacy checkout/browse, catalog,
+cart, orders, payment, subscription lifecycle) is reachable through one
+consistent function-per-operation shape, sharing two executor primitives
+(`execute_tap_request_with_acro`, `execute_tap_request_with_custom_nonce`) so
+that TAP signing and HTTP request construction are implemented exactly once.
+
+### Out of Scope
+
+- The MCP wire protocol / tool registration itself (JSON-RPC framing, stdio
+  transport) — that's [[020-tap-mcp-server-binary]]
+- Merchant-specific endpoint/field mapping — that's [[015-merchant-abstraction]]
+- Whether ACRO actually reaches the wire for body-bearing requests — already
+  fully analyzed in [[011-process-payment-acro-wire-contract]]; this spec
+  states the current behavior as fact without re-litigating it
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `Product` / `ProductVariant` / `ProductCatalog` | Standard catalog wire format | merchant-agnostic; `MerchantApi` implementors convert to/from this shape |
+| `CartItem` / `CartState` | Standard cart wire format | same conversion pattern |
+| `Order` / `OrderLineItem` / `OrderStatus` / `Address` | Standard order wire format | `OrderStatus` is an enum |
+| `PaymentResult` / `PaymentStatus` | Standard payment result | `PaymentStatus` is an enum |
+| `PlanId` / `SubscriptionId` | Validated newtype IDs (non-empty, ≤64 chars) | constructed only via `::new()` |
+| `Subscription<State>` | Typestate-pattern subscription; `State ∈ {Trial, Active, Paused, PastDue, Canceled, Expired}` | consuming transition methods return the next state type, making illegal transitions a compile error |
+| `PricingModel` | Flat / Tiered / PerSeat / Usage / Hybrid pricing | `minimum_price() -> Decimal` |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN any tool function in this module sends an HTTP request THE SYSTEM SHALL route it through exactly one of the two executors in `http.rs` (`execute_tap_request_with_acro` or `execute_tap_request_with_custom_nonce`) rather than constructing requests ad hoc | must |
+| FR-2 | WHEN `execute_tap_request_with_acro` is called with `request_body = Some(_)` THE SYSTEM SHALL send `request_body` as the wire body and SHALL NOT transmit the generated ACRO object; WHEN called with `request_body = None` THE SYSTEM SHALL serialize the ACRO object itself as the entire wire body | must |
+| FR-3 | WHEN `payment::process_payment` executes THE SYSTEM SHALL use `execute_tap_request_with_custom_nonce` so that the APC nonce and the HTTP signature nonce are identical | must |
+| FR-4 | WHEN any path segment supplied to an executor contains a `.` or `..` component THE SYSTEM SHALL reject the call via `reject_path_traversal` before constructing the request | must |
+| FR-5 | WHEN an HTTP response with a 3xx status is received by the shared `reqwest::Client` (built via `create_http_client`) THE SYSTEM SHALL NOT follow it (`Policy::none()`) — the response is surfaced as-is to the caller | must |
+| FR-6 | WHEN `validate_consumer_id` receives a consumer ID THE SYSTEM SHALL reject it unless non-empty, ≤64 characters, and composed only of alphanumerics, `-`, and `_` | must |
+| FR-7 | WHEN `parse_merchant_url` receives a merchant URL THE SYSTEM SHALL require HTTPS, EXCEPT WHEN the `TAP_ALLOW_LOOPBACK` environment variable is set to `1`, in which case `http://localhost` and `http://127.0.0.1` are also accepted | must |
+| FR-8 | WHEN a `Subscription<State>` transition method is called on a state that does not define that transition THE SYSTEM SHALL fail to compile (no runtime state-transition validation is needed for statically-known transitions) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Security | `TAP_ALLOW_LOOPBACK=1` is a documented escape hatch for local testing; it must never be set in production merchant integrations. This is flagged in `.claude/rules/continuous-improvement.md` § Security Audit Depth as an item requiring continued scrutiny |
+| NFR-2 | Consistency | All 12+ tool functions (`checkout_with_tap`, `browse_merchant`, `get_products`, `get_product`, `add_to_cart`, `get_cart`, `update_cart_item`, `remove_from_cart`, `create_order`, `get_order`, `process_payment`, `process_payment_rate_limited`, plus 11 subscription tools) follow the identical `async fn(&TapSigner, Params) -> Result<T>` shape |
+| NFR-3 | Testability | Inline `#[cfg(test)]` modules exist per file across `mcp/` and `mcp/subscriptions/` |
+| NFR-4 | Duplication | `execute_tap_request_with_acro` and `execute_tap_request_with_custom_nonce` share substantial logic (nonce handling, ACRO generation, header construction); issue #240 tracks deduplicating them into a shared executor — this spec documents the current pre-deduplication state |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| Search/query parameter exceeds `MAX_SEARCH_PARAM_LENGTH` (256 chars) | Rejected by `validate_search_param` before the request is sent |
+| Search parameter contains a NUL byte or non-graphic character | Rejected by `validate_search_param` |
+| Base URL has a trailing slash and path starts with `/` | `compose_request_url` avoids the resulting double-slash |
+| Merchant responds with a non-2xx status | Surfaced as `BridgeError::MerchantError`, never silently retried inside this module (retry is a caller/`reliability` concern) |
+| `process_payment` receives ACRO-context fields (`country_code`, `zip`, etc.) | Per [[011-process-payment-acro-wire-contract]], these are currently signed into an ACRO that is generated but never transmitted for this call path — tracked as a known defect in that spec, not restated as correct behavior here |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Add new tool functions following the existing `async fn(&TapSigner, Params) -> Result<T>` shape
+- Route new HTTP calls through the existing executors in `http.rs`, not a new ad hoc client
+
+### Ask First
+- Deduplicating `execute_tap_request_with_acro` / `execute_tap_request_with_custom_nonce` (issue #240) — significant refactor touching every call site
+- Changing `TAP_ALLOW_LOOPBACK` semantics or default
+
+### Never
+- Bypass `reject_path_traversal` or `validate_consumer_id` for a new call site
+- Re-enable HTTP redirect following on the shared client (`create_http_client`) — see [[005-redirects-leak-tap-headers]] and [[006-incomplete-redirect-fix]] for why this was disabled
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: is issue #240's executor deduplication scheduled, and should it be coordinated with the FR-5 follow-up from spec 011 (extending the ACRO-discard fix to add_to_cart/update_cart_item/remove_from_cart/subscription mutations)?]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[001-cart-id-silently-dropped]] — precedent bug in this subsystem (cart tools)
+- [[003-rate-limit-not-per-consumer]] — `process_payment_rate_limited` behavior history
+- [[004-id-fields-path-traversal]] — origin of `reject_path_traversal` (FR-4)
+- [[005-redirects-leak-tap-headers]], [[006-incomplete-redirect-fix]] — origin of the no-redirect policy (FR-5)
+- [[011-process-payment-acro-wire-contract]] — deep analysis of FR-2's ACRO transmission rule and its `process_payment` defect
+- [[015-merchant-abstraction]] — the trait layer this module's tools convert to/from
+- [[020-tap-mcp-server-binary]] — where these functions are registered as MCP tools

--- a/specs/015-merchant-abstraction/spec.md
+++ b/specs/015-merchant-abstraction/spec.md
@@ -1,0 +1,110 @@
+# Spec 015 — `merchant` Subsystem: Merchant API Abstraction and TOML Configuration
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-bridge/src/merchant/{mod,traits,default,config,endpoint,field_map,transform,subscription_config,subscription_traits}.rs`,
+`tap-mcp-bridge/examples/merchants/*.toml`
+
+> [!note]
+> Describes existing, tested code — including the extensive input-validation
+> surface added in response to prior findings (issues #150, #143).
+
+## 1. Overview
+
+### Problem Statement
+
+Merchants expose different REST conventions — endpoint paths, field names,
+pagination styles, auth schemes. The bridge cannot hardcode one merchant's
+shape. The `merchant` module provides a trait-based abstraction
+(`MerchantApi` + `EndpointResolver` + `FieldMapper` + optional
+`RequestTransformer`/`ResponseTransformer`) so a merchant integration is
+expressed as data (a TOML file) rather than new Rust code, with
+`DefaultMerchant` as the out-of-box implementation for standard-TAP-shaped
+merchants.
+
+### Goal
+
+A merchant integrator can describe their API surface entirely in a TOML file
+(base URL, endpoint templates, field-name mappings, pagination style, auth)
+and have `DefaultMerchant::from_toml` (or `::from_file`) produce a working
+`MerchantApi` implementation, validated against injection and SSRF-adjacent
+attack patterns before use.
+
+### Out of Scope
+
+- The subscription-specific mirror types (`SubscriptionMerchantConfig`, etc.)
+  are documented at the type level here but their business logic
+  (proration, pricing) is covered in [[014-mcp-tool-surface]]
+- Actual HTTP transport — that's [[016-transport-layer]]
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `MerchantApi` (trait) | Central abstraction every merchant integration implements | associated types `ProductCatalog`, `Product`, `CartState`, `Order`, `PaymentResult`; methods `endpoint_resolver()`, `field_mapper()`, optional `request_transformer()`/`response_transformer()`, `to_standard_*` conversions |
+| `EndpointResolver` (trait) | Maps logical operations to concrete paths | `products_endpoint`, `product_endpoint`, `cart_endpoint`, `add_to_cart_endpoint`, `update_cart_item_endpoint`, `remove_cart_item_endpoint`, `create_order_endpoint`, `order_endpoint`, `checkout_endpoint` |
+| `FieldMapper` (trait) | Maps standard field names to merchant-specific ones | `map_request_field`, `map_response_field`, `has_custom_mappings` |
+| `MerchantConfig` | Deserialized TOML root | `name, base_url, api_prefix, endpoints, field_mappings, auth: Option<AuthConfig>, pagination` |
+| `AuthConfig` | Tagged enum for auth scheme | `ApiKey{header,env_var} \| Bearer{env_var} \| OAuth2{token_url,client_id_env,client_secret_env}` |
+| `PaginationStyle` | Tagged enum | `PageBased (default) \| OffsetBased \| CursorBased` |
+| `DefaultMerchant` | Standard-TAP `MerchantApi` implementation | `config: MerchantConfig`, `endpoint_resolver: ConfigurableEndpointResolver`, `field_mapper: ConfigurableFieldMapper` |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN `DefaultMerchant::from_toml` or `::from_file` loads a config THE SYSTEM SHALL call `MerchantConfig::validate()` before returning a usable instance | must |
+| FR-2 | WHEN `base_url` or an OAuth2 `token_url` is validated THE SYSTEM SHALL require HTTPS and SHALL reject loopback hosts (`localhost`, `127.0.0.0/8`, `::1`, IPv4-mapped IPv6 loopback), unspecified addresses (`0.0.0.0`, `::`), userinfo in the URL, and port `0` | must |
+| FR-3 | WHEN an endpoint template is validated THE SYSTEM SHALL reject templates containing `..`, `//`, not starting with `/`, or containing NUL/`?`/`#`/whitespace | must |
+| FR-4 | WHEN a field-mapping name is validated THE SYSTEM SHALL reject empty names, prototype-pollution-shaped names (`__proto__`, `constructor`, `prototype`, `__defineGetter__`, case-insensitively), NUL bytes, and SQL-injection-shaped patterns (`'; drop`, `-- `, `/*`, `*/`) | must |
+| FR-5 | WHEN an auth config env-var name is validated THE SYSTEM SHALL require it start with a letter or underscore and contain only alphanumerics/underscores thereafter; header names SHALL be restricted to the RFC 7230 token subset (alphanumeric, `-`, `_`) | must |
+| FR-6 | WHEN a `MerchantApi` implementor's methods run THE SYSTEM SHALL convert between the merchant's native response shape and the standard wire types defined in [[014-mcp-tool-surface]] via `to_standard_*` methods | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Security | Validation is exhaustive enough to have a dedicated "Regression tests for issue #150" block in `config.rs` covering unspecified-address, IPv4-mapped-loopback, userinfo, port-0, and path-traversal edge cases together |
+| NFR-2 | Extensibility | Adding a new merchant integration requires only a new TOML file (and, for non-standard field/pagination conventions, no Rust code at all) — `DefaultMerchant` is intended to cover the majority case |
+| NFR-3 | Testability | `config.rs` alone carries roughly 50 inline tests; every other file in the module has its own `#[cfg(test)]` block |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| `base_url` points at `http://api.example.com` (no TLS) | Rejected by `validate_https_url` at load time — `MerchantConfigError` |
+| `base_url` resolves to `0.0.0.0` or `::` | Rejected by `host_is_disallowed` (unspecified-address check) |
+| Endpoint template is `/cart/../admin` | Rejected — traversal pattern |
+| Field mapping maps `"total"` → `"__proto__"` | Rejected — prototype-pollution pattern, case-insensitive |
+| Auth env-var name is `"9_TOKEN"` (starts with digit) | Rejected — must start with letter or underscore |
+| A merchant's response omits a field the `FieldMapper` expects | Behavior is implementation-specific per `MerchantApi` impl; `DefaultMerchant`'s conversions are the reference behavior, not enforced generically by the trait |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Run `MerchantConfig::validate()` (directly or via `from_toml`/`from_file`) before using any loaded config
+- Keep new merchant TOML fixtures under `tap-mcp-bridge/examples/merchants/` in sync with schema changes (per `.claude/rules/branching.md`)
+
+### Ask First
+- Loosening any of the FR-2 through FR-5 validation rules — each corresponds to a specific historical finding (issue #150, #143)
+- Adding a new `AuthConfig` variant or `PaginationStyle` variant — changes the TOML schema surface
+
+### Never
+- Skip `validate()` when loading merchant config from an untrusted or user-editable source
+- Allow endpoint templates or field-mapping names sourced from config to be interpolated into requests without the FR-3/FR-4 checks
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: is there a plan to support merchant config sources other than local TOML files (e.g. remote-fetched config), and if so, does the current validate()-on-load pattern need to move to validate-on-every-use?]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[004-id-fields-path-traversal]] — related path-traversal finding (in `mcp`, not `merchant`, but same defect class as FR-3)
+- [[014-mcp-tool-surface]] — the standard wire types this module's `to_standard_*` conversions target
+- `tap-mcp-bridge/examples/merchants/standard-tap.toml`, `acme-store.toml`, `shopify-style.toml` — reference configs

--- a/specs/016-transport-layer/spec.md
+++ b/specs/016-transport-layer/spec.md
@@ -1,0 +1,107 @@
+# Spec 016 — `transport` Subsystem: Sealed HTTP Transport Abstraction
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-bridge/src/transport/{mod,config,sealed}.rs`, `transport/http/mod.rs`
+
+> [!note]
+> Describes existing, tested code.
+
+## 1. Overview
+
+### Problem Statement
+
+Every outbound request the bridge makes must go through TAP-signed HTTP —
+there must be no way for a caller (in this crate or a future external crate)
+to construct a transport that bypasses the security checks (HTTPS
+enforcement, loopback rejection, path sanitization, header injection
+prevention) that TAP requires. The `transport` module defines a `Transport`
+trait that is **sealed**, so only this crate can implement it, with
+`HttpTransport` as the sole current implementation over `reqwest`.
+
+### Goal
+
+A `Transport` implementor exposes `get`/`post`/`put`/`delete` returning a
+uniform `TransportResponse`, while internally enforcing HTTPS-only,
+loopback-rejecting, traversal-safe, CRLF-safe requests, leaving room for
+future protocols (HTTP/3, gRPC) without changing the trait's public shape.
+
+### Out of Scope
+
+- The TAP-signing-specific request executors in `mcp/http.rs` (which build on
+  top of a plain `reqwest::Client`, not this module's `Transport` trait) —
+  see [[014-mcp-tool-surface]]. The two HTTP client configurations
+  (`mcp/http.rs`'s `create_http_client` and this module's
+  `DEFAULT_HTTP_CLIENT`) are separate, parallel client instances with
+  equivalent but independently maintained security settings
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `Transport` (trait, sealed) | Uniform async HTTP interface | `get/post/put/delete` (RPITIT futures), `protocol_name() -> &'static str`, `supports_streaming() -> bool` (default `false`) |
+| `RequestContext<'a>` | Per-request parameters | `base_url, path, headers: Vec<(&str,&str)>, content_type: Option<&str>, interaction_type: InteractionType` |
+| `TransportResponse` | Uniform response shape | `status: u16, body: Vec<u8>, headers: Vec<(String,String)>` |
+| `HttpTransport` | The sole current `Transport` implementor | `client: Client, http_version: HttpVersion` |
+| `TransportConfig` | Tagged config enum | `Http(HttpConfig) \| Http2(HttpConfig)` |
+| `HttpConfig` | Tunable client parameters | `pool_max_idle_per_host, timeout_secs, connect_timeout_secs, http_version` |
+| `HttpVersion` | Protocol selection | `Http1 \| Http2 \| Auto (default)` |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | THE SYSTEM SHALL prevent any type outside this crate from implementing `Transport`, via a `pub(crate)` sealing trait in `sealed.rs` | must |
+| FR-2 | WHEN `HttpConfig` is validated THE SYSTEM SHALL require `timeout_secs` in `1..=300` and `connect_timeout_secs` in `1..=60`, rejecting values outside those ranges | must |
+| FR-3 | WHEN a URL is validated (`validate_url`) THE SYSTEM SHALL require HTTPS and SHALL reject `localhost`/`127.0.0.1`/`::1`/`[::1]` hosts | must |
+| FR-4 | WHEN a path is sanitized (`sanitize_path`) THE SYSTEM SHALL reject `..` and `//` segments and SHALL require the path to start with `/` | must |
+| FR-5 | WHEN a header name or value is validated (`validate_header`) THE SYSTEM SHALL reject any CR, LF, or NUL byte (CRLF/header injection prevention) | must |
+| FR-6 | WHEN the module-local `DEFAULT_HTTP_CLIENT` singleton is used THE SYSTEM SHALL disable automatic redirect following | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Defaults | `pool_max_idle_per_host = 100`, `timeout_secs = 30`, `connect_timeout_secs = 10`, `http_version = Auto` |
+| NFR-2 | Extensibility | The `Transport` trait's shape (async methods returning `TransportResponse`, `protocol_name`, `supports_streaming`) is designed to accommodate future HTTP/3 or gRPC implementors without a breaking change, per the module doc comment |
+| NFR-3 | Testability | Inline `#[cfg(test)]` coverage exists for `RequestContext`/`TransportResponse` construction and equivalent validation logic in `http/mod.rs` |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| `timeout_secs = 0` or `> 300` | `HttpConfig::validate()` rejects it (`TransportError`) |
+| URL scheme is `http://` | Rejected by `validate_url` |
+| Path is `/cart/../admin` | Rejected by `sanitize_path` |
+| Header value contains `\r\n` | Rejected by `validate_header` |
+| A future protocol needs `supports_streaming() == true` | Override the default method on the new implementor; no trait-level change required |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Run new outbound requests through `HttpTransport` (or a future sealed implementor), never a bare unvalidated `reqwest::Client`
+- Keep the sealed-trait pattern (`sealed.rs`) intact when adding new `Transport` methods
+
+### Ask First
+- Adding a new `Transport` implementor (HTTP/3, gRPC, JSON-RPC) — significant new surface
+- Consolidating this module's HTTP client configuration with `mcp/http.rs`'s separate `create_http_client` (currently two parallel, independently-configured clients with equivalent security posture — a DRY opportunity, not yet acted on)
+
+### Never
+- Remove or weaken the `sealed` trait bound on `Transport`
+- Re-enable redirect following on `DEFAULT_HTTP_CLIENT`
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: should transport::http and mcp::http's parallel HTTP client configurations be unified into a single shared client factory, given they enforce equivalent but independently-maintained security settings? This is a DRY candidate per the arch-audit requirements in .claude/rules/continuous-improvement.md.]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[005-redirects-leak-tap-headers]], [[006-incomplete-redirect-fix]] — history behind FR-6's no-redirect policy (originally found in `mcp/http.rs`'s client, not this module's, but the same posture applies here)
+- [[014-mcp-tool-surface]] — the parallel, TAP-signing-specific HTTP client this module does not itself drive
+- `tap-mcp-bridge/src/transport/mod.rs` — module entry point

--- a/specs/017-reliability-patterns/spec.md
+++ b/specs/017-reliability-patterns/spec.md
@@ -1,0 +1,101 @@
+# Spec 017 — `reliability` Subsystem: Retry with Backoff and Circuit Breaker
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-bridge/src/reliability/{mod,retry,circuit_breaker}.rs`
+
+> [!note]
+> Describes existing, tested code. Rate limiting is a related but separate
+> reliability concern implemented in the `security` module — see
+> [[018-security-hardening]] — not in this one, despite the name suggesting
+> otherwise; this is confirmed directly from the module's own doc comment.
+
+## 1. Overview
+
+### Problem Statement
+
+Merchant endpoints are external services and will occasionally fail
+transiently (network blips, momentary overload). Callers need a standard way
+to retry with exponential backoff, and a way to stop hammering a merchant that
+is persistently failing (circuit breaker), without every call site
+reimplementing this logic.
+
+### Goal
+
+`RetryPolicy` + `retry_with_backoff` gives any async operation configurable
+exponential-backoff retry; `CircuitBreaker` gives any operation a
+three-state (Closed/Open/HalfOpen) failure-isolation wrapper. Both are
+general-purpose and not TAP-specific — they take arbitrary async closures.
+
+### Out of Scope
+
+- Rate limiting (token bucket) — implemented in `security::rate_limit`, see
+  [[018-security-hardening]]
+- Any specific merchant-call integration of these primitives — this spec
+  documents the primitives themselves, not where they are or aren't yet wired
+  into `mcp` tool functions
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `RetryPolicy` | Exponential backoff configuration | `max_attempts, initial_delay, max_delay, backoff_multiplier`; `Default`: `3, 100ms, 5s, 2.0` |
+| `CircuitState` | Three-state enum, `#[repr(u8)]` for atomic storage | `Closed = 0, Open = 1, HalfOpen = 2` |
+| `CircuitBreakerConfig` | Thresholds and timeout | `failure_threshold, success_threshold, reset_timeout`; defaults `failure_threshold=5, success_threshold=2` |
+| `CircuitBreaker` | Atomic state machine wrapping an operation | internally `AtomicU8`/`AtomicU64` counters + `tokio::sync::RwLock` |
+| `CircuitBreakerError` | `thiserror` error type for breaker rejections | — |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN `retry_with_backoff` retries a failed operation THE SYSTEM SHALL compute the delay for attempt N as `initial_delay * backoff_multiplier^(N-1)`, capped at `max_delay` | must |
+| FR-2 | WHEN `retry_with_backoff` reaches `max_attempts` without success THE SYSTEM SHALL return the last error, not retry further | must |
+| FR-3 | WHEN a `CircuitBreaker` in `Closed` state observes `failure_threshold` consecutive failures THE SYSTEM SHALL transition to `Open` | must |
+| FR-4 | WHEN a `CircuitBreaker` in `Open` state has been open for at least `reset_timeout` THE SYSTEM SHALL transition to `HalfOpen` on the next call attempt | must |
+| FR-5 | WHEN a `CircuitBreaker` in `HalfOpen` state observes `success_threshold` consecutive successes THE SYSTEM SHALL transition to `Closed`; WHEN it observes any failure in `HalfOpen` THE SYSTEM SHALL transition back to `Open` | must |
+| FR-6 | WHEN `is_retryable` classifies an error THE SYSTEM SHALL determine whether `retry_with_backoff` should attempt another call for that error kind | should |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Concurrency | `CircuitBreaker` state is stored in atomics (`AtomicU8` state, `AtomicU64` counters) so concurrent callers observe consistent state without a full mutex on the hot path |
+| NFR-2 | Testability | `retry.rs` and `circuit_breaker.rs` each carry inline `#[cfg(test)]` coverage plus doc-tests demonstrating state transitions |
+| NFR-3 | Performance | No `criterion` benchmark exists for either primitive — not flagged as a Critical Path in `.claude/rules/continuous-improvement.md`, so this is a lower-priority gap than the `tap`/`jwe` benchmark gaps |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| `max_attempts = 1` | No retries occur; the first failure is returned immediately |
+| Computed delay would exceed `max_delay` | Delay is capped at `max_delay`, not left unbounded |
+| A call is attempted while the breaker is `Open` and `reset_timeout` has not yet elapsed | The call is rejected immediately via `CircuitBreakerError`, without invoking the wrapped operation |
+| A single failure occurs while `HalfOpen` | Breaker reopens immediately (does not require reaching `failure_threshold` again while half-open) |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Use `retry_with_backoff`/`CircuitBreaker` for new merchant-call resilience needs rather than hand-rolled retry loops
+
+### Ask First
+- Changing default `RetryPolicy`/`CircuitBreakerConfig` values — affects every current caller's behavior
+- Wiring `CircuitBreaker` into a new call site that doesn't currently have one — worth confirming the failure mode is actually transient/circuit-appropriate
+
+### Never
+- Retry non-idempotent operations (e.g. payment submission) without confirming idempotency at the merchant/API level first
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: which of the mcp tool functions in specs 014 currently have retry_with_backoff and/or CircuitBreaker wired in, versus relying on caller-side retry? This spec documents the primitives; a follow-up audit could map actual call-site adoption.]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[018-security-hardening]] — the sibling subsystem holding the token-bucket rate limiter (not this one)
+- `tap-mcp-bridge/src/reliability/mod.rs` — module entry point and doc comment clarifying scope

--- a/specs/018-security-hardening/spec.md
+++ b/specs/018-security-hardening/spec.md
@@ -1,0 +1,103 @@
+# Spec 018 — `security` Subsystem: Rate Limiting and Audit Logging
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-bridge/src/security/{mod,rate_limit,audit}.rs`
+
+> [!note]
+> Describes existing, tested code. The replay-protection nonce cache — often
+> assumed to live here — is actually implemented in `tap::verifier::NonceCache`
+> and is documented in [[012-tap-protocol-implementation]], not this spec;
+> this was confirmed by reading the source directly.
+
+## 1. Overview
+
+### Problem Statement
+
+Two distinct concerns live in this module: (1) preventing a single caller or
+key from overwhelming a merchant or the bridge itself (token-bucket rate
+limiting), and (2) producing a structured, redacted audit trail of
+security-relevant events (signature generation, checkout attempts,
+authentication failures, rate-limit hits) for later forensic review.
+
+### Goal
+
+`RateLimiter`/`KeyedRateLimiter` give per-process or per-key request-rate
+control; `RateLimitedSigner` wraps `TapSigner` so signing itself can be
+rate-limited; `AuditEvent`/`audit_log` give a consistent, redaction-aware
+logging path for security events.
+
+### Out of Scope
+
+- Replay-protection nonce cache — see [[012-tap-protocol-implementation]]
+- Circuit breaker / retry — see [[017-reliability-patterns]]
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `RateLimitConfig` | Token-bucket parameters | `requests_per_second, burst_size`; `Default`: `10, 5` |
+| `RateLimiter` | Single-bucket limiter | `tokens: AtomicU64` (fixed-point ×1000), `last_update: Mutex<Instant>` |
+| `KeyedRateLimiter` | Per-key limiter via bounded `LruCache` | `::new(config, capacity: NonZeroUsize)` |
+| `RateLimitedSigner` | Wraps `TapSigner` with rate limiting applied to signing itself | `::new(signer, config)` |
+| `AuditEventType` | Enumerated security event kinds | `SignatureGenerated, CheckoutAttempted, CheckoutSucceeded, CheckoutFailed, BrowseAttempted, BrowseSucceeded, AuthenticationFailed, RateLimitExceeded, CircuitBreakerStateChanged` |
+| `AuditDetails` | Optional contextual fields on an event | `merchant_url, consumer_id, nonce, error, duration_ms` (all `Option`) |
+| `AuditEvent` | The logged unit | `timestamp, event_type, agent_id, request_id: Uuid, details` |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN `RateLimiter::acquire` is called and no tokens are available THE SYSTEM SHALL return `Err(RateLimitExceeded)` without blocking; WHEN `acquire_blocking` is called under the same condition THE SYSTEM SHALL wait until a token becomes available | must |
+| FR-2 | WHEN `KeyedRateLimiter::acquire(key)` is called for a key not yet tracked THE SYSTEM SHALL create a fresh bucket for that key, evicting the least-recently-used tracked key if the configured capacity is exceeded | must |
+| FR-3 | WHEN an `AuditEvent` is constructed with a consumer ID THE SYSTEM SHALL recommend (via `redact_consumer_id`) pre-redaction before attaching it to `AuditDetails` | should |
+| FR-4 | WHEN `redact_sensitive` processes a string containing card numbers, CVV, or SSN-shaped data THE SYSTEM SHALL redact it before it reaches an audit log entry | must |
+| FR-5 | WHEN a rate limit is exceeded THE SYSTEM SHALL itself emit an audit event (`RateLimitExceeded` `AuditEventType`), so rate-limit hits are forensically visible | should |
+| FR-6 | THE SYSTEM SHALL write audit logs to a separate `tracing` target from general application logs, allowing independent filtering | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Concurrency | `RateLimiter`'s token count is atomic (`AtomicU64`, fixed-point) with a mutex-guarded `last_update` timestamp — safe under concurrent `acquire` calls |
+| NFR-2 | Defaults | `RateLimitConfig::default()` is `requests_per_second=10, burst_size=5`; `KeyedRateLimiter` capacity has no default constant — callers must supply a `NonZeroUsize` |
+| NFR-3 | Testability | Inline `#[cfg(test)]` coverage exists in both `rate_limit.rs` and `audit.rs` |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| `KeyedRateLimiter` capacity reached and a new key requests a bucket | The least-recently-used existing key's bucket is evicted (standard LRU semantics) |
+| `RateLimitedSigner::sign_request` is called when the wrapped rate limit is exhausted | Returns an error (via the underlying `RateLimitExceeded`) rather than signing |
+| An `AuditDetails.consumer_id` is attached without prior redaction | Not automatically redacted by `AuditEvent` construction itself — redaction is caller-applied via `redact_consumer_id`, per FR-3's "should" (not "must") — a caller that forgets this step will leak a raw consumer ID into logs |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Call `redact_consumer_id`/`redact_sensitive` before attaching caller-supplied strings to `AuditDetails`
+- Route new rate-limiting needs through `RateLimiter`/`KeyedRateLimiter` rather than a new ad hoc mechanism
+
+### Ask First
+- Changing default `RateLimitConfig` values (affects every current caller)
+- Making FR-3 (consumer-ID redaction) mandatory/automatic at the `AuditEvent` construction level rather than caller-applied — would be a safety improvement but changes the API contract
+
+### Never
+- Log unredacted card numbers, CVV, SSNs, or full consumer IDs through the audit path
+- Bypass rate limiting for a production call path without an explicit, reviewed justification
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: should AuditEvent's consumer_id field require pre-redacted input at the type level (e.g. a RedactedConsumerId newtype) rather than relying on callers to remember to call redact_consumer_id? Current FR-3 is a "should", not enforced by the type system.]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[003-rate-limit-not-per-consumer]] — prior finding about `process_payment_rate_limited` not being per-consumer; relevant history for FR-1/FR-2's per-key vs. global distinction
+- [[012-tap-protocol-implementation]] — the separate replay-protection nonce cache, not part of this subsystem
+- [[017-reliability-patterns]] — the sibling subsystem for retry/circuit-breaker
+- `tap-mcp-bridge/src/security/mod.rs` — module entry point

--- a/specs/019-observability/spec.md
+++ b/specs/019-observability/spec.md
@@ -1,0 +1,107 @@
+# Spec 019 — `observability` Subsystem: Logging, Health Checks, Metrics
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-server/src/observability.rs`
+
+> [!warning]
+> Unlike the other subsystem specs in this batch, this one documents a
+> **partially-dead-code state**, not a fully wired subsystem. `Metrics` is
+> defined, tested, and can render Prometheus text output, but is never
+> constructed or incremented anywhere in `tap-mcp-server/src/main.rs` — the
+> whole module carries `#![allow(dead_code, reason = "Metrics struct prepared
+> for future integration")]`. This spec records that fact rather than
+> describing aspirational "wired" behavior.
+
+## 1. Overview
+
+### Problem Statement
+
+The `tap-mcp-server` binary needs structured logging (for operational
+debugging), a health-check payload (`verify_agent_identity` MCP tool), and —
+eventually — Prometheus-exportable metrics. This module (binary-local, not
+part of the `tap-mcp-bridge` library) implements all three, but only the
+first two are actually exercised by `main.rs` today.
+
+### Goal
+
+`init_observability` wires `tracing_subscriber` with an `EnvFilter` and a
+JSON-or-pretty formatter; `HealthReport`/`HealthCheck` back the
+`verify_agent_identity` tool's response; `Metrics` exists as a ready-to-adopt
+counter set with Prometheus exposition formatting, awaiting integration into
+the actual request path.
+
+### Out of Scope
+
+- Metrics integration itself (i.e. actually calling `record_checkout_success`
+  etc. from `mcp` tool call sites) — not yet done; this spec documents the
+  current state, it does not perform the integration
+- Structured audit logging (`AuditEvent`) — that is a library concern, see
+  [[018-security-hardening]]
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `LogFormat` | Output format selector | `Pretty \| Json`; `from_env()` reads `LOG_FORMAT` |
+| `HealthStatus` | Overall health | `Healthy \| Degraded \| Unhealthy` |
+| `HealthCheckStatus` | Per-check result | `Pass \| Fail \| Warn` |
+| `HealthCheck` | One named check result | `name, status, message: Option<String>` |
+| `HealthReport` | Full health payload | `status, version, agent_id, uptime_secs, checks: Vec<HealthCheck>, metrics: Option<MetricsSnapshot>` |
+| `Metrics` | Atomic counters (currently unwired) | `checkout_requests, checkout_successes, checkout_failures, browse_requests, signature_generations, http_errors` — all `AtomicU64` |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN `init_observability(format)` runs THE SYSTEM SHALL configure a `tracing_subscriber` registry with an `EnvFilter` sourced from `RUST_LOG` (default `"info"`) and a formatting layer (JSON or pretty per `format`) writing to `stderr` with `FmtSpan::CLOSE` span events | must |
+| FR-2 | WHEN `HealthReport::compute_status` evaluates a set of `HealthCheck`s THE SYSTEM SHALL return `Unhealthy` if any check is `Fail`, else `Degraded` if any check is `Warn`, else `Healthy` | must |
+| FR-3 | WHEN `HealthReport::to_json` serializes a report THE SYSTEM SHALL build it via `serde_json::json!` in a way that preserves key order (a fix for a prior key-ordering regression, #138/#139) | must |
+| FR-4 | WHEN `Metrics::to_prometheus` is called THE SYSTEM SHALL render counters in Prometheus text exposition format with names prefixed `tap_` (e.g. `tap_checkout_requests_total`) | must |
+| FR-5 | THE SYSTEM SHALL NOT currently construct or increment any `Metrics` counter from `tap-mcp-server/src/main.rs` — the `verify_agent_identity` tool's response sets `metrics: None` with an explicit `// TODO` marker | must (documents current state) |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Configuration | `LOG_FORMAT` (`json`\|`pretty`, default `pretty`) and `RUST_LOG` (default `info`) are the only two env vars this module reads |
+| NFR-2 | Testability | Inline `#[cfg(test)]` module covers `LogFormat` env parsing, `HealthCheck` constructors, `HealthReport` JSON shape (including the key-order regression test), `Metrics` counter behavior, and Prometheus text-format assertions |
+| NFR-3 | Scope | Prometheus metrics are not currently scraped by anything — no HTTP endpoint exists in `tap-mcp-server` to expose `to_prometheus()`'s output. The function is tested but has no caller in `main.rs` |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| `LOG_FORMAT` is unset or has an unrecognized value | Falls back to `Pretty` (`from_env`'s else-branch) |
+| A `HealthCheck` has `status: Fail` alongside other `Pass` checks | `compute_status` returns `Unhealthy` — `Fail` dominates `Warn` and `Pass` |
+| `verify_agent_identity` is called | Returns a `HealthReport` with `metrics: None` (FR-5) — callers cannot currently observe request counters through this tool |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Preserve the `serde_json::json!`-based key-order-preserving construction in `HealthReport::to_json` (FR-3) — do not refactor to a struct-derived `Serialize` without re-verifying key order, per the #138/#139 regression history
+
+### Ask First
+- Wiring `Metrics` into actual MCP tool call sites (`checkout_with_tap`, `browse_merchant`, etc.) and exposing a Prometheus scrape endpoint — this is real, scoped feature work, not documentation; it should go through its own `/sdd specify` → `/sdd plan` cycle rather than being bundled into an unrelated change
+- Removing the `#![allow(dead_code, ...)]` on this module — only do so once `Metrics` actually has a caller
+
+### Never
+- Silently start incrementing `Metrics` counters from only some call sites while leaving others unwired — partial instrumentation is worse than none because it implies false completeness
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: is Prometheus metrics integration still planned (README/CHANGELOG reference it as a "production feature"), and if so, is a pull-based scrape endpoint or push-based exporter the intended design? This determines whether main.rs needs a second listener alongside the MCP stdio transport.]`
+- `[NEEDS CLARIFICATION: should this module move into the tap-mcp-bridge library (so any binary embedding the bridge gets the same health/metrics shape), or does it stay tap-mcp-server-specific by design?]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[002-json-key-ordering-regression]] — the #138/#139 incident behind FR-3's key-order preservation requirement
+- [[018-security-hardening]] — the library-side audit-logging counterpart to this binary-side observability module
+- [[020-tap-mcp-server-binary]] — where `init_observability` and `HealthReport` are actually invoked
+- `.claude/rules/continuous-improvement.md` § Performance & Benchmark Coverage — `observability_overhead` is the workspace's only existing benchmark, and it targets this module

--- a/specs/020-tap-mcp-server-binary/spec.md
+++ b/specs/020-tap-mcp-server-binary/spec.md
@@ -1,0 +1,104 @@
+# Spec 020 — `tap-mcp-server` Binary: MCP Stdio Server Exposing TAP Tools
+
+**Status**: Documented (as-built)
+**Priority**: N/A (subsystem documentation, not a fix)
+**Type**: Subsystem specification — documents existing behavior
+**Owner**: N/A
+**Discovered**: Authored during specs migration cycle, 2026-08-08, closing the
+subsystem-coverage gap against `.claude/rules/continuous-improvement.md` §
+Project Subsystems
+**Source**: `tap-mcp-server/src/main.rs`
+
+> [!note]
+> Describes existing, tested code. This is the binary crate that consumes
+> [[014-mcp-tool-surface]]'s library functions and exposes them over the
+> Model Context Protocol.
+
+## 1. Overview
+
+### Problem Statement
+
+An MCP-compatible AI agent client (e.g. Claude Desktop) needs to discover and
+invoke TAP operations as MCP tools over a standard transport. `tap-mcp-server`
+is the binary that loads agent credentials from the environment, builds a
+`TapSigner`, registers every `mcp` library function as an MCP tool, and serves
+them over stdio using JSON-RPC 2.0 framing.
+
+### Goal
+
+Running `tap-mcp-server` with three required environment variables
+(`TAP_AGENT_ID`, `TAP_AGENT_DIRECTORY`, `TAP_SIGNING_KEY`) produces a working
+MCP server an agent client can `initialize` and `tools/list`/`tools/call`
+against, with graceful shutdown on Ctrl-C.
+
+### Out of Scope
+
+- The tool implementations themselves — see [[014-mcp-tool-surface]]
+- Logging/health-check internals — see [[019-observability]]
+
+## 2. Data Model
+
+| Entity | Description | Key Attributes |
+|--------|-------------|-----------------|
+| `Config` | Validated startup configuration | loaded via `Config::from_env()` |
+| `TapMcpServer` | The MCP service implementor | `Arc<TapSigner>`, `ToolRouter`, start time, `agent_id`; manual `Debug` redacts the signer field as `"[TapSigner]"` |
+| Per-tool request wrapper structs | e.g. `CheckoutRequest`, `BrowseRequest` | derive `Deserialize + JsonSchema`; map 1:1 into the corresponding `mcp::*Params` type |
+| `EmptyRequest` | Zero-field request marker for parameterless tools | Declared as `struct EmptyRequest {}` (brace form), not a unit struct |
+
+## 3. Functional Requirements
+
+| ID | Requirement | Priority |
+|----|------------|----------|
+| FR-1 | WHEN the binary starts THE SYSTEM SHALL read and validate `TAP_AGENT_ID` (alphanumeric + `-`/`_`, 1–64 chars), `TAP_AGENT_DIRECTORY` (must be `https://`, must reject loopback hosts, userinfo, port 0, and `.`/`..` path segments), and `TAP_SIGNING_KEY` (exactly 64 hex characters / 32 bytes, must reject any all-bytes-equal seed) before constructing a signer | must |
+| FR-2 | WHEN `TAP_SIGNING_KEY` decodes to a seed where every byte is equal (all-zero, all-`0xff`, or any other repeated byte) THE SYSTEM SHALL reject startup, since such a key is publicly derivable | must |
+| FR-3 | WHEN the server starts THE SYSTEM SHALL call `init_observability` before config validation output is needed, so startup errors are captured by the configured log format | must |
+| FR-4 | THE SYSTEM SHALL register exactly these MCP tools via `#[tool_router]`/`#[tool]`: `checkout_with_tap`, `browse_merchant`, `get_products`, `get_product`, `add_to_cart`, `get_cart`, `update_cart_item`, `remove_from_cart`, `create_order`, `get_order`, `process_payment`, `verify_agent_identity` | must |
+| FR-5 | WHEN a tool takes no parameters THE SYSTEM SHALL use `Parameters<EmptyRequest>` (brace-form empty struct) rather than `Parameters<()>`, so the emitted JSON Schema is `type: "object"` rather than `type: "null"` (regression fix for #120) | must |
+| FR-6 | WHEN the server reports its identity (MCP `initialize` response) THE SYSTEM SHALL override `ServerInfo` via `Implementation::new(CARGO_PKG_NAME, CARGO_PKG_VERSION)` so clients see `tap-mcp-server`'s own name/version, not the underlying `rmcp` framework's build identity | must |
+| FR-7 | WHEN the process receives `Ctrl-C` (or the MCP service's `waiting()` future completes) THE SYSTEM SHALL shut down gracefully via `tokio::select!` between the two futures | must |
+| FR-8 | WHEN `verify_agent_identity` is invoked THE SYSTEM SHALL report signing-key-loaded status, a JWKS-generation check, process uptime, and version — as a `HealthReport` (see [[019-observability]]) | must |
+
+## 4. Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-1 | Transport | MCP is served exclusively over stdio (`rmcp::transport::stdio()`) with JSON-RPC 2.0 framing; no network listener exists in this binary |
+| NFR-2 | Configuration | All configuration is environment-variable-based: `TAP_AGENT_ID`, `TAP_AGENT_DIRECTORY`, `TAP_SIGNING_KEY` (required), `RUST_LOG` (optional, default `info`), `LOG_FORMAT` (optional, default `pretty`) |
+| NFR-3 | Testability | Inline `#[cfg(test)]` module in `main.rs` covers config validation (including the loopback/userinfo/port-0/traversal/all-equal-byte-key regressions), signer creation, `get_info` identity, tool-list completeness (regression #121), and empty-request schema shape (regression #120) |
+| NFR-4 | Secrets | `TAP_SIGNING_KEY` is read directly from the process environment by this binary at runtime — this is the one place in the project where a `TAP_*` secret is expected to come from an env var rather than the Zeph vault, since the binary itself has no vault integration; the vault is a development-workflow concern for this repo's own contributors, not a deployment requirement for consumers of the binary |
+
+## 5. Edge Cases and Error Handling
+
+| Scenario | Expected Behavior |
+|----------|--------------------|
+| `TAP_AGENT_DIRECTORY` is `https://user:pass@directory.example/` (userinfo present) | Startup rejected |
+| `TAP_AGENT_DIRECTORY` path contains `..` | Startup rejected (regression #149 class) |
+| `TAP_SIGNING_KEY` is 64 hex chars of all `0`s or all `f`s | Startup rejected (regression #148 class) |
+| A tool call arrives before `initialize` completes | Handled by the underlying `rmcp` service lifecycle, not this binary's own logic |
+| Ctrl-C arrives while a tool call is in flight | `tokio::select!` races shutdown against the service's `waiting()` future; in-flight call completion behavior is governed by `rmcp`'s own service shutdown semantics, not re-implemented here |
+
+## 6. Agent Boundaries
+
+### Always (without asking)
+- Keep `Config::from_env()` as the single validation choke point for all three required env vars
+- Keep the tool list in FR-4 in sync with `tap-mcp-bridge`'s `mcp` module — if a new library tool function is added, register it here or explicitly note it is intentionally not yet exposed
+
+### Ask First
+- Adding a network-based transport (HTTP/SSE) alongside stdio — currently stdio-only by design
+- Adding new required environment variables — expands the deployment contract for every consumer
+
+### Never
+- Read `TAP_SIGNING_KEY` (or any secret) from a file path or hardcoded default — env-var-only per FR-1
+- Expose `ServerInfo` reflecting the underlying `rmcp` framework's identity instead of `tap-mcp-server`'s own (FR-6)
+
+## 7. Open Questions
+
+- `[NEEDS CLARIFICATION: is a network transport (HTTP/SSE per newer MCP spec revisions) planned, given rmcp 3.x's feature set now supports it, or is stdio-only a deliberate, permanent scope boundary for this binary?]`
+
+## 8. See Also
+
+- [[MOC-specs]] — all specifications
+- [[007-weak-signing-keys-accepted]] — origin of FR-2's all-equal-byte-key rejection
+- [[014-mcp-tool-surface]] — the library functions registered as tools here
+- [[019-observability]] — `init_observability`/`HealthReport`, invoked from this binary's startup and `verify_agent_identity` respectively
+- `tap-mcp-server/src/main.rs` — full implementation and inline tests

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -1,8 +1,19 @@
 # Map of Content — Specifications
 
-Living index of specs under `specs/`. Each spec corresponds to a
-non-trivial finding (P0–P2 bug, enhancement, research gap) and is the source
-of truth for the WHAT and WHY; `/sdd plan` artefacts capture the HOW.
+Living index of specs under `specs/`. Two categories of spec live here:
+
+- **Finding specs (001–011)**: each corresponds to a non-trivial finding
+  (P0–P2 bug, enhancement, research gap) and is the source of truth for the
+  WHAT and WHY; `/sdd plan` artefacts capture the HOW.
+- **Subsystem specs (012–020)**: document the current, as-built behavior of
+  each logical subsystem tracked in
+  `.claude/rules/continuous-improvement.md` § Project Subsystems. They were
+  authored to close a coverage gap — the finding specs are point fixes, not
+  a comprehensive record of what the system does — and describe existing,
+  tested code rather than proposing new work. See each subsystem spec's own
+  `[!note]` callout for this framing.
+
+## Finding Specs
 
 | Spec | Title | Priority | Status | Discovered |
 |------|-------|---------|--------|-----------|
@@ -21,3 +32,23 @@ of truth for the WHAT and WHY; `/sdd plan` artefacts capture the HOW.
 Note: #149 (TAP_AGENT_DIRECTORY validator gaps) had no separate spec — the issue body covered it. Closed by #152 in cycle 21.
 
 Note: #150 (TOML validator bundle) had no separate spec — issue body covered the four validator sections. Closed by #154 in cycle 23 via shared `validate_https_url` helper + extended endpoint-path checks.
+
+## Subsystem Specs
+
+| Spec | Subsystem | Status | Discovered |
+|------|-----------|--------|-----------|
+| [012](012-tap-protocol-implementation/spec.md) | `tap` — RFC 9421 signatures, JWK/JWT, ACRO/APC | Documented (as-built) | Specs migration, 2026-08-08 |
+| [013](013-jwe-encryption/spec.md) | `jwe` — RFC 7516 compact serialization for APC | Documented (as-built) | Specs migration, 2026-08-08 |
+| [014](014-mcp-tool-surface/spec.md) | `mcp` — TAP operations exposed as callable tools | Documented (as-built) | Specs migration, 2026-08-08 |
+| [015](015-merchant-abstraction/spec.md) | `merchant` — `MerchantApi` abstraction + TOML config | Documented (as-built) | Specs migration, 2026-08-08 |
+| [016](016-transport-layer/spec.md) | `transport` — sealed HTTP transport abstraction | Documented (as-built) | Specs migration, 2026-08-08 |
+| [017](017-reliability-patterns/spec.md) | `reliability` — retry with backoff, circuit breaker | Documented (as-built) | Specs migration, 2026-08-08 |
+| [018](018-security-hardening/spec.md) | `security` — rate limiting, audit logging | Documented (as-built) | Specs migration, 2026-08-08 |
+| [019](019-observability/spec.md) | `observability` — logging, health checks, metrics (`tap-mcp-server`) | Documented (as-built; metrics unwired) | Specs migration, 2026-08-08 |
+| [020](020-tap-mcp-server-binary/spec.md) | `tap-mcp-server` — MCP stdio server binary | Documented (as-built) | Specs migration, 2026-08-08 |
+
+No root-level BRD/SRS/NFR was added: `README.md` and `tap-mcp-bridge/src/lib.rs`'s
+module-level rustdoc already cover product-level WHAT/WHY at a level judged
+sufficient; a redundant BRD was not deemed to add value. Likewise, no
+`constitution.md`/`TEMPLATE.md`/`ARCHITECTURE.md` was copied from sibling
+projects — none of that content currently exists in this repo to migrate.

--- a/specs/MOC-specs.md
+++ b/specs/MOC-specs.md
@@ -1,0 +1,23 @@
+# Map of Content — Specifications
+
+Living index of specs under `specs/`. Each spec corresponds to a
+non-trivial finding (P0–P2 bug, enhancement, research gap) and is the source
+of truth for the WHAT and WHY; `/sdd plan` artefacts capture the HOW.
+
+| Spec | Title | Priority | Status | Discovered |
+|------|-------|---------|--------|-----------|
+| [001](001-cart-id-silently-dropped/spec.md) | `update_cart_item` and `remove_from_cart` silently drop required `cart_id` | P1 | Resolved (#132) | Cycle 7, 2026-05-01 |
+| [002](002-json-key-ordering-regression/spec.md) | JSON object key ordering changed silently after #130 (loss of `serde_json/preserve_order`) | P2 | Resolved (#139) | Cycle 9, 2026-05-01 |
+| [003](003-rate-limit-not-per-consumer/spec.md) | `process_payment_rate_limited` is process-global despite "per consumer" claim | P1 | Resolved (#141, Position A) | Cycle 11, 2026-05-01 |
+| [004](004-id-fields-path-traversal/spec.md) | id-fields embedded in URL paths via `format!()` enable path-traversal across 14 tool functions | P1 | Resolved (#143, Position A + defense-in-depth) | Cycle 13, 2026-05-01 |
+| [005](005-redirects-leak-tap-headers/spec.md) | HTTP redirects leak signed TAP headers and ACRO body to redirect target | P1 | Resolved (#145 + #147) | Cycle 15, 2026-05-01 |
+| [006](006-incomplete-redirect-fix/spec.md) | #145 missed `mcp::tools::HTTP_CLIENT`; redirect leak persists for `browse_merchant` + `checkout_with_tap` | P1 | Resolved (#147, includes shared `tap_http_client_builder()` factory) | Cycle 16, 2026-05-01 |
+| [007](007-weak-signing-keys-accepted/spec.md) | `TAP_SIGNING_KEY` validator accepts all-zero / all-ones / low-entropy seeds | P2 | Resolved (#151, all-byte-equal rejection per Position A) | Cycle 18, 2026-05-01 |
+| [008](008-replay-cache-lru-eviction/spec.md) | `TapVerifier`'s LRU eviction creates a replay-protection bypass | P2 | Resolved (#155, Position B from spec) | Cycle 20, 2026-05-01 |
+| [009](009-rsa-pss-signing-support/spec.md) | `tap-mcp-bridge` signs exclusively with Ed25519; official TAP reference agent also supports RSA-PSS-SHA256 | P2 | Draft | Cycle 26, 2026-08-08 |
+| [010](010-ap2-x402-landscape-tracking/spec.md) | Track Google Agent Payments Protocol (AP2) and its x402 crypto-payment extension as an emerging parallel standard to Visa TAP | P4 | Open — tracking | Cycle 26, 2026-08-08 |
+| [011](011-process-payment-acro-wire-contract/spec.md) | `process_payment` discards ACRO/ID-token signature; ACRO has no wire slot for any body-bearing TAP request (resolves #239) | P1 | Draft | Cycle 27, 2026-08-08 |
+
+Note: #149 (TAP_AGENT_DIRECTORY validator gaps) had no separate spec — the issue body covered it. Closed by #152 in cycle 21.
+
+Note: #150 (TOML validator bundle) had no separate spec — issue body covered the four validator sections. Closed by #154 in cycle 23 via shared `validate_https_url` helper + extended endpoint-path checks.


### PR DESCRIPTION
## Summary
- Move the SDD spec archive from the untracked `.local/specs/` working folder to a git-tracked top-level `specs/` directory, matching the convention used in sibling projects (zeph, exarch, mcp-execution)
- All 11 existing specs (`001`-`011`) and `MOC-specs.md` moved as-is, with internal path references updated from `.local/specs/` to `specs/`
- Add 9 new subsystem specs (`012`-`020`) documenting the current, as-built behavior of every logical subsystem tracked in `.claude/rules/continuous-improvement.md` (tap, jwe, mcp, merchant, transport, reliability, security, observability, tap-mcp-server), none of which previously had dedicated spec coverage
- Update `CHANGELOG.md` under `[Unreleased]`

## Test plan
- [x] Docs/file-reorganization only, no source code touched
- [x] `git status` clean, no stray files
- [x] Verified no other tracked file (README, CLAUDE.md, `.claude/rules/*.md`) still references `.local/specs/`